### PR TITLE
Add PNG EXIF metadata extraction with regex processing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,13 @@
             <version>4.5.14</version>
         </dependency>
 
+        <!-- Metadata Extractor for EXIF and other image metadata -->
+        <dependency>
+            <groupId>com.drewnoakes</groupId>
+            <artifactId>metadata-extractor</artifactId>
+            <version>2.19.0</version>
+        </dependency>
+
         <!-- JUnit -->
 
         <dependency>

--- a/src/main/java/com/github/exadmin/cyberferret/utils/FileUtils.java
+++ b/src/main/java/com/github/exadmin/cyberferret/utils/FileUtils.java
@@ -11,6 +11,20 @@ public class FileUtils {
     }
 
     public static String readFile(Path filePath) throws IOException {
+        // Check if this is an image file that should have metadata extracted
+        String extension = getFileExtensionAsString(filePath);
+        if (ImageMetadataExtractor.isSupportedImageFormat(extension)) {
+            // Extract and return metadata as searchable text
+            String metadata = ImageMetadataExtractor.extractMetadataAsText(filePath);
+
+            // If metadata extraction succeeded, return it
+            // Otherwise fall back to reading file as text (empty metadata means extraction failed)
+            if (!metadata.isEmpty()) {
+                return metadata;
+            }
+        }
+
+        // For non-image files or if metadata extraction failed, read as text
         byte[] bytes = Files.readAllBytes(filePath);
         return new String(bytes);
     }

--- a/src/main/java/com/github/exadmin/cyberferret/utils/ImageMetadataExtractor.java
+++ b/src/main/java/com/github/exadmin/cyberferret/utils/ImageMetadataExtractor.java
@@ -1,0 +1,119 @@
+package com.github.exadmin.cyberferret.utils;
+
+import com.drew.imaging.ImageMetadataReader;
+import com.drew.imaging.ImageProcessingException;
+import com.drew.metadata.Directory;
+import com.drew.metadata.Metadata;
+import com.drew.metadata.Tag;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+/**
+ * Utility class for extracting metadata from image files (PNG, JPEG, etc.)
+ * Extracts EXIF, IPTC, XMP, and other metadata that can be searched with regex patterns.
+ */
+public class ImageMetadataExtractor {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ImageMetadataExtractor.class);
+
+    /**
+     * Extracts all metadata from an image file and returns it as formatted text.
+     * The text format allows regex pattern matching on metadata fields.
+     *
+     * @param imagePath Path to the image file
+     * @return Formatted string containing all metadata, or empty string if extraction fails
+     */
+    public static String extractMetadataAsText(Path imagePath) {
+        if (imagePath == null) {
+            LOGGER.warn("Image path is null");
+            return "";
+        }
+
+        try {
+            Metadata metadata = ImageMetadataReader.readMetadata(imagePath.toFile());
+            return formatMetadataAsText(metadata);
+        } catch (ImageProcessingException e) {
+            LOGGER.debug("Failed to process image metadata for {}: {}", imagePath, e.getMessage());
+            return "";
+        } catch (IOException e) {
+            LOGGER.debug("Failed to read image file {}: {}", imagePath, e.getMessage());
+            return "";
+        } catch (Exception e) {
+            LOGGER.warn("Unexpected error extracting metadata from {}: {}", imagePath, e.getMessage());
+            return "";
+        }
+    }
+
+    /**
+     * Formats extracted metadata as searchable text.
+     * Each metadata tag is formatted as "DirectoryName.TagName: value"
+     *
+     * Example output:
+     * <pre>
+     * PNG-IHDR.Image Width: 1920
+     * PNG-IHDR.Image Height: 1080
+     * PNG-tEXt.Author: John Doe
+     * Exif IFD0.Software: Adobe Photoshop
+     * Exif IFD0.Artist: Jane Smith
+     * </pre>
+     *
+     * @param metadata Metadata object from metadata-extractor library
+     * @return Formatted string representation
+     */
+    private static String formatMetadataAsText(Metadata metadata) {
+        StringBuilder sb = new StringBuilder();
+
+        for (Directory directory : metadata.getDirectories()) {
+            String directoryName = directory.getName();
+
+            // Add each tag in the directory
+            for (Tag tag : directory.getTags()) {
+                String tagName = tag.getTagName();
+                String tagValue = tag.getDescription();
+
+                if (tagValue != null && !tagValue.trim().isEmpty()) {
+                    sb.append(directoryName)
+                      .append(".")
+                      .append(tagName)
+                      .append(": ")
+                      .append(tagValue)
+                      .append("\n");
+                }
+            }
+
+            // Add any errors encountered
+            if (directory.hasErrors()) {
+                for (String error : directory.getErrors()) {
+                    LOGGER.debug("Metadata directory '{}' error: {}", directoryName, error);
+                }
+            }
+        }
+
+        return sb.toString();
+    }
+
+    /**
+     * Checks if a file extension indicates an image file that may contain metadata.
+     *
+     * @param extension File extension (without dot)
+     * @return true if the extension is for a supported image format
+     */
+    public static boolean isSupportedImageFormat(String extension) {
+        if (extension == null) {
+            return false;
+        }
+
+        String ext = extension.toLowerCase();
+        return ext.equals("png") ||
+               ext.equals("jpg") ||
+               ext.equals("jpeg") ||
+               ext.equals("gif") ||
+               ext.equals("bmp") ||
+               ext.equals("tiff") ||
+               ext.equals("tif") ||
+               ext.equals("webp") ||
+               ext.equals("ico");
+    }
+}


### PR DESCRIPTION
- Add metadata-extractor library dependency (v2.19.0) to pom.xml
- Create ImageMetadataExtractor utility to extract EXIF and other metadata from PNG and other image files
- Modify FileUtils.readFile() to detect image files and extract metadata as searchable text
- Extracted metadata is automatically processed by existing regex pattern matching in RunnableScanner
- Supports PNG, JPEG, GIF, BMP, TIFF, WebP, and ICO formats
- Metadata is formatted as "DirectoryName.TagName: value" for easy regex matching
- Allows detection of sensitive information in image metadata (author, GPS, software, etc.)