### PR TITLE
Honor Git ignore rules during repository scans

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,15 +9,20 @@ includes newly created source files that have not been added to Git yet.
 
 Cyber Ferret skips files excluded by standard Git rules, including repository `.gitignore` files,
 `.git/info/exclude`, and the user's global Git excludes file. Git must be available on `PATH` to scan a Git
-repository. When you scan a directory that is not a Git repository, Cyber Ferret scans all files under that directory.
+repository. When you scan a directory that is not a Git repository, Cyber Ferret scans regular files without following
+symbolic links to directories or entering `.git` directories.
+
+Checked-out Git submodules are scanned recursively. Cyber Ferret does not follow symbolic links to directories, so a
+tracked link cannot make a scan traverse an external repository. Symbolic links to regular files remain scannable.
+On Unix systems, the scanner also preserves and scans file names that contain byte sequences that are not valid UTF-8.
 
 # Example
 [<img src="./docs/run-example.gif">]()
 
 # How to build from sources via command line
 ## Prerequisites
-* Install JDK (24 or newer) from https://jdk.java.net/24/
-* Install JavaFX (24 or newer) from https://gluonhq.com/products/javafx/
+* Install [JDK 21 or newer](https://jdk.java.net/21/)
+* Install [JavaFX 21 or newer](https://gluonhq.com/products/javafx/)
 * Install Apache Maven (ver 3.9.x) from https://maven.apache.org/download.cgi
 * Setup M2_HOME, JAVA_HOME and PATH (add maven and java) System Variables as recommended for Java and Maven usage
 * Optional = setup JAVAFX_PATH System Variable for handy run of the application using predefined shell-scripts in ./fx/src/shell/*.* 
@@ -60,10 +65,14 @@ or use ./fx/src/shell/run-app.sh file
 
 # How to run - in IntelliJ IDEA
 ## prerequisites
-Install JDK from https://jdk.java.net/24/
-Install JavaFX from https://gluonhq.com/products/javafx/
+Install [JDK 21 or newer](https://jdk.java.net/21/)
+Install [JavaFX 21 or newer](https://gluonhq.com/products/javafx/)
 Create Run/Debug Configuration Profile of type "Application"
-Set VM options "--module-path "...\JDKs\javafx-sdk-24.0.1\lib" --add-modules  javafx.controls,javafx.web,javafx.graphics --enable-native-access=javafx.graphics"
+Set VM options:
+
+```shell
+--module-path "...\JDKs\javafx-sdk-21\lib" --add-modules javafx.controls,javafx.web,javafx.graphics --enable-native-access=javafx.graphics
+```
 
 
 # Dictionary format

--- a/README.md
+++ b/README.md
@@ -3,6 +3,14 @@
 
 Scans any files for different pre-defined signatures (supporting RegExp and other rules)
 
+# Git repository scanning
+When you scan a Git repository, Cyber Ferret scans tracked files and untracked files that Git does not ignore. This
+includes newly created source files that have not been added to Git yet.
+
+Cyber Ferret skips files excluded by standard Git rules, including repository `.gitignore` files,
+`.git/info/exclude`, and the user's global Git excludes file. Git must be available on `PATH` to scan a Git
+repository. When you scan a directory that is not a Git repository, Cyber Ferret scans all files under that directory.
+
 # Example
 [<img src="./docs/run-example.gif">]()
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ On Unix systems, the scanner also preserves and scans file names that contain by
 * Install [JDK 21 or newer](https://jdk.java.net/21/)
 * Install [JavaFX 21 or newer](https://gluonhq.com/products/javafx/)
 * Install Apache Maven (ver 3.9.x) from https://maven.apache.org/download.cgi
+* Install [Git](https://git-scm.com/downloads) and ensure `git` is available on `PATH`
 * Setup M2_HOME, JAVA_HOME and PATH (add maven and java) System Variables as recommended for Java and Maven usage
 * Optional = setup JAVAFX_PATH System Variable for handy run of the application using predefined shell-scripts in ./fx/src/shell/*.* 
 

--- a/cli/src/main/java/com/github/exadmin/cyberferret/CyberFerretCLI.java
+++ b/cli/src/main/java/com/github/exadmin/cyberferret/CyberFerretCLI.java
@@ -11,12 +11,9 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.nio.file.SimpleFileVisitor;
-import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -180,26 +177,6 @@ public class CyberFerretCLI {
     }
 
     static List<Path> loadFilesFromRepository(Path rootPathToScan) throws IOException {
-        List<Path> files = new ArrayList<>();
-        Files.walkFileTree(rootPathToScan, new SimpleFileVisitor<>() {
-            @Override
-            public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) {
-                if (dir.getFileName().toString().equals(".git")) {
-                    return FileVisitResult.SKIP_SUBTREE;
-                }
-                return FileVisitResult.CONTINUE;
-            }
-
-            @Override
-            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
-                if (attrs.isRegularFile()) {
-                    Path path = file.normalize();
-                    files.add(path);
-                    ConsoleUtils.trace("Repository file = " + path);
-                }
-                return FileVisitResult.CONTINUE;
-            }
-        });
-        return files;
+        return new RepositoryFileLoader().load(rootPathToScan);
     }
 }

--- a/cli/src/test/java/com/github/exadmin/cyberferret/CyberFerretCLIGitIgnoreTests.java
+++ b/cli/src/test/java/com/github/exadmin/cyberferret/CyberFerretCLIGitIgnoreTests.java
@@ -20,6 +20,9 @@ public class CyberFerretCLIGitIgnoreTests {
         Path repository = tempDir.resolve("repository");
         Files.createDirectories(repository);
         runGit(repository, "init");
+        Path emptyExcludesFile = tempDir.resolve("empty-global-excludes");
+        Files.writeString(emptyExcludesFile, "", StandardCharsets.UTF_8);
+        runGit(repository, "config", "core.excludesFile", emptyExcludesFile.toString());
 
         Path untrackedSource = repository.resolve("NewSource.java");
         Path gitIgnored = repository.resolve("ignored.txt");

--- a/cli/src/test/java/com/github/exadmin/cyberferret/CyberFerretCLIGitIgnoreTests.java
+++ b/cli/src/test/java/com/github/exadmin/cyberferret/CyberFerretCLIGitIgnoreTests.java
@@ -1,0 +1,57 @@
+package com.github.exadmin.cyberferret;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class CyberFerretCLIGitIgnoreTests {
+    @TempDir
+    Path tempDir;
+
+    @Test
+    public void loadFilesFromRepository_skipsGitIgnoredFilesButKeepsUntrackedFiles() throws Exception {
+        Path repository = tempDir.resolve("repository");
+        Files.createDirectories(repository);
+        runGit(repository, "init");
+
+        Path untrackedSource = repository.resolve("NewSource.java");
+        Path gitIgnored = repository.resolve("ignored.txt");
+        Path locallyExcluded = repository.resolve("local.secret");
+        Files.writeString(untrackedSource, "content", StandardCharsets.UTF_8);
+        Files.writeString(gitIgnored, "content", StandardCharsets.UTF_8);
+        Files.writeString(locallyExcluded, "content", StandardCharsets.UTF_8);
+        Files.writeString(repository.resolve(".gitignore"), "ignored.txt\n", StandardCharsets.UTF_8);
+        Files.writeString(
+                repository.resolve(".git/info/exclude"),
+                "*.secret\n",
+                StandardCharsets.UTF_8);
+
+        List<Path> files = CyberFerretCLI.loadFilesFromRepository(repository);
+
+        assertTrue(files.contains(untrackedSource.toAbsolutePath().normalize()));
+        assertFalse(files.contains(gitIgnored.toAbsolutePath().normalize()));
+        assertFalse(files.contains(locallyExcluded.toAbsolutePath().normalize()));
+    }
+
+    private static void runGit(Path repository, String... arguments) throws Exception {
+        String[] command = new String[arguments.length + 3];
+        command[0] = "git";
+        command[1] = "-C";
+        command[2] = repository.toString();
+        System.arraycopy(arguments, 0, command, 3, arguments.length);
+
+        Process process = new ProcessBuilder(command).redirectErrorStream(true).start();
+        String output = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+        int exitCode = process.waitFor();
+        if (exitCode != 0) {
+            throw new IllegalStateException("Git command failed: " + output);
+        }
+    }
+}

--- a/common/src/main/java/com/github/exadmin/cyberferret/async/RunnableScanner.java
+++ b/common/src/main/java/com/github/exadmin/cyberferret/async/RunnableScanner.java
@@ -7,6 +7,7 @@ import com.github.exadmin.cyberferret.model.FoundPathItem;
 import com.github.exadmin.cyberferret.model.ItemType;
 import com.github.exadmin.cyberferret.utils.FileUtils;
 import com.github.exadmin.cyberferret.utils.MiscUtils;
+import com.github.exadmin.cyberferret.utils.RepositoryFileLoader;
 
 import java.io.File;
 import java.io.IOException;
@@ -190,6 +191,20 @@ public class RunnableScanner extends ARunnable {
             Path rootDir,
             ExcludeFileModel excludeFileModel,
             FoundItemsContainer foundItemsContainer) throws IOException {
+        RepositoryFileLoader repositoryFileLoader = new RepositoryFileLoader();
+        boolean applyGitExclusions = repositoryFileLoader.isGitRepository(rootDir);
+        Set<Path> includedFiles = applyGitExclusions
+                ? new HashSet<>(repositoryFileLoader.load(rootDir))
+                : Set.of();
+        Set<Path> includedDirectories = new HashSet<>();
+        for (Path includedFile : includedFiles) {
+            Path directory = includedFile.getParent();
+            while (directory != null && directory.startsWith(rootDir)) {
+                includedDirectories.add(directory);
+                directory = directory.getParent();
+            }
+        }
+
         Deque<FoundPathItem> parentsDeque = new ArrayDeque<>();
         Files.walkFileTree(rootDir, new FileVisitor<>() {
             @Override
@@ -198,6 +213,10 @@ public class RunnableScanner extends ARunnable {
 
                 // todo: move this hard code to some configurable place, priority = normal
                 if (dir.getFileName().toString().equals(".git")) return FileVisitResult.SKIP_SUBTREE;
+                if (applyGitExclusions
+                        && !includedDirectories.contains(dir.toAbsolutePath().normalize())) {
+                    return FileVisitResult.SKIP_SUBTREE;
+                }
 
                 FoundPathItem parent = parentsDeque.peekLast();
                 FoundPathItem foundPathItem = new FoundPathItem(dir, ItemType.DIRECTORY, parent);
@@ -212,6 +231,10 @@ public class RunnableScanner extends ARunnable {
             @Override
             public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
                 logTrace("Visiting file {}", file);
+                if (applyGitExclusions
+                        && !includedFiles.contains(file.toAbsolutePath().normalize())) {
+                    return FileVisitResult.CONTINUE;
+                }
 
                 FoundPathItem parent = parentsDeque.peekLast();
                 FoundPathItem foundPathItem = new FoundPathItem(file, ItemType.FILE, parent);

--- a/common/src/main/java/com/github/exadmin/cyberferret/async/RunnableScanner.java
+++ b/common/src/main/java/com/github/exadmin/cyberferret/async/RunnableScanner.java
@@ -193,9 +193,18 @@ public class RunnableScanner extends ARunnable {
             FoundItemsContainer foundItemsContainer) throws IOException {
         RepositoryFileLoader repositoryFileLoader = new RepositoryFileLoader();
         boolean applyGitExclusions = repositoryFileLoader.isGitRepository(rootDir);
-        Set<Path> includedFiles = applyGitExclusions
-                ? new HashSet<>(repositoryFileLoader.load(rootDir))
-                : Set.of();
+        Set<Path> includedFiles;
+        try {
+            includedFiles = applyGitExclusions
+                    ? new HashSet<>(repositoryFileLoader.load(rootDir))
+                    : Set.of();
+        } catch (IOException ex) {
+            fxCallback.showMessage(
+                    FxCallback.FxCallbackType.ERROR,
+                    "Cannot enumerate Git repository files: " + ex.getMessage()
+                            + ". Verify that Git is installed and the repository is valid.");
+            throw ex;
+        }
         Set<Path> includedDirectories = new HashSet<>();
         for (Path includedFile : includedFiles) {
             Path directory = includedFile.getParent();

--- a/common/src/main/java/com/github/exadmin/cyberferret/utils/GitPathKey.java
+++ b/common/src/main/java/com/github/exadmin/cyberferret/utils/GitPathKey.java
@@ -1,0 +1,86 @@
+package com.github.exadmin.cyberferret.utils;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.Arrays;
+
+final class GitPathKey {
+    private static final byte SEPARATOR = (byte) '/';
+
+    private final byte[] value;
+
+    private GitPathKey(byte[] value) {
+        this.value = value;
+    }
+
+    static GitPathKey fromGitOutput(byte[] output, int start, int end) {
+        return new GitPathKey(Arrays.copyOfRange(output, start, end));
+    }
+
+    static GitPathKey fromNativePath(Path root, Path path) throws IOException {
+        String rootPath = root.toUri().getRawPath();
+        if (!rootPath.endsWith("/")) {
+            rootPath += "/";
+        }
+
+        String pathValue = path.toUri().getRawPath();
+        if (!pathValue.startsWith(rootPath)) {
+            throw new IOException("Repository path is outside the scan root: " + path);
+        }
+
+        String relativePath = pathValue.substring(rootPath.length());
+        if (relativePath.endsWith("/")) {
+            relativePath = relativePath.substring(0, relativePath.length() - 1);
+        }
+        return new GitPathKey(decodeUriPath(relativePath));
+    }
+
+    GitPathKey parent() {
+        for (int index = value.length - 1; index >= 0; index--) {
+            if (value[index] == SEPARATOR) {
+                return new GitPathKey(Arrays.copyOf(value, index));
+            }
+        }
+        return null;
+    }
+
+    private static byte[] decodeUriPath(String rawPath) throws IOException {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream(rawPath.length());
+        for (int index = 0; index < rawPath.length(); index++) {
+            char current = rawPath.charAt(index);
+            if (current == '%') {
+                if (index + 2 >= rawPath.length()) {
+                    throw new IOException("Invalid encoded repository path: " + rawPath);
+                }
+                int high = Character.digit(rawPath.charAt(index + 1), 16);
+                int low = Character.digit(rawPath.charAt(index + 2), 16);
+                if (high < 0 || low < 0) {
+                    throw new IOException("Invalid encoded repository path: " + rawPath);
+                }
+                bytes.write((high << 4) + low);
+                index += 2;
+                continue;
+            }
+
+            int codePoint = rawPath.codePointAt(index);
+            byte[] encoded = new String(Character.toChars(codePoint)).getBytes(StandardCharsets.UTF_8);
+            bytes.writeBytes(encoded);
+            if (Character.isSupplementaryCodePoint(codePoint)) {
+                index++;
+            }
+        }
+        return bytes.toByteArray();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other instanceof GitPathKey otherKey && Arrays.equals(value, otherKey.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.hashCode(value);
+    }
+}

--- a/common/src/main/java/com/github/exadmin/cyberferret/utils/RepositoryFileLoader.java
+++ b/common/src/main/java/com/github/exadmin/cyberferret/utils/RepositoryFileLoader.java
@@ -8,7 +8,9 @@ import java.nio.file.Path;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -39,17 +41,17 @@ public class RepositoryFileLoader {
     }
 
     private List<Path> loadFromGit(Path root) throws IOException {
+        byte[] trackedOutput = executeGitLsFiles(root, "--cached", "--stage", "-z");
+        byte[] untrackedOutput = executeGitLsFiles(root, "--others", "--exclude-standard", "-z");
+        return loadSelectedPaths(root, parseGitSelection(trackedOutput, untrackedOutput));
+    }
+
+    private byte[] executeGitLsFiles(Path root, String... arguments) throws IOException {
         Process process;
         try {
             List<String> command = new ArrayList<>(gitCommand);
-            command.addAll(List.of(
-                    "-C",
-                    root.toString(),
-                    "ls-files",
-                    "--cached",
-                    "--others",
-                    "--exclude-standard",
-                    "-z"));
+            command.addAll(List.of("-C", root.toString(), "ls-files"));
+            command.addAll(List.of(arguments));
             process = new ProcessBuilder(command).start();
         } catch (IOException ex) {
             throw new IOException("Cannot start Git to list repository files", ex);
@@ -77,16 +79,39 @@ public class RepositoryFileLoader {
             throw new IOException("Cannot list Git repository files: " + message);
         }
 
-        List<Path> files = new ArrayList<>();
+        return output;
+    }
+
+    private GitSelection parseGitSelection(byte[] trackedOutput, byte[] untrackedOutput) {
+        Set<GitPathKey> files = new HashSet<>();
+        Set<GitPathKey> directories = new HashSet<>();
+        Set<GitPathKey> submodules = new HashSet<>();
+        addGitEntries(trackedOutput, true, files, directories, submodules);
+        addGitEntries(untrackedOutput, false, files, directories, submodules);
+        return new GitSelection(files, directories, submodules);
+    }
+
+    private void addGitEntries(
+            byte[] output,
+            boolean hasStageMetadata,
+            Set<GitPathKey> files,
+            Set<GitPathKey> directories,
+            Set<GitPathKey> submodules) {
         int entryStart = 0;
         for (int index = 0; index < output.length; index++) {
             if (output[index] != 0) {
                 continue;
             }
-            addGitPath(root, output, entryStart, index, files);
+            addGitEntry(
+                    output,
+                    entryStart,
+                    index,
+                    hasStageMetadata,
+                    files,
+                    directories,
+                    submodules);
             entryStart = index + 1;
         }
-        return files;
     }
 
     private byte[] readProcessOutput(Future<byte[]> outputFuture) throws IOException, InterruptedException {
@@ -97,28 +122,96 @@ public class RepositoryFileLoader {
         }
     }
 
-    private void addGitPath(
-            Path root,
+    private void addGitEntry(
             byte[] output,
             int entryStart,
             int entryEnd,
-            List<Path> files) throws IOException {
+            boolean hasStageMetadata,
+            Set<GitPathKey> files,
+            Set<GitPathKey> directories,
+            Set<GitPathKey> submodules) {
         if (entryStart == entryEnd) {
             return;
         }
-        String relativePath = new String(
-                output,
-                entryStart,
-                entryEnd - entryStart,
-                StandardCharsets.UTF_8);
-        Path file = root.resolve(relativePath).normalize();
-        if (file.startsWith(root) && Files.isRegularFile(file)) {
-            files.add(file);
-        } else if (file.startsWith(root)
-                && Files.isDirectory(file)
-                && isGitRepository(file)) {
-            files.addAll(loadFromGit(file));
+        int pathStart = entryStart;
+        boolean isSubmodule = false;
+        if (hasStageMetadata) {
+            for (int index = entryStart; index < entryEnd; index++) {
+                if (output[index] != '\t') {
+                    continue;
+                }
+                isSubmodule = hasGitMode(output, entryStart, index, "160000");
+                pathStart = index + 1;
+                break;
+            }
         }
+
+        GitPathKey path = GitPathKey.fromGitOutput(output, pathStart, entryEnd);
+        if (isSubmodule) {
+            submodules.add(path);
+        } else {
+            files.add(path);
+        }
+        for (GitPathKey parent = path.parent(); parent != null; parent = parent.parent()) {
+            directories.add(parent);
+        }
+    }
+
+    private boolean hasGitMode(
+            byte[] output,
+            int entryStart,
+            int metadataEnd,
+            String expectedMode) {
+        byte[] mode = expectedMode.getBytes(StandardCharsets.US_ASCII);
+        if (metadataEnd - entryStart < mode.length) {
+            return false;
+        }
+        for (int index = 0; index < mode.length; index++) {
+            if (output[entryStart + index] != mode[index]) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private List<Path> loadSelectedPaths(Path root, GitSelection selection) throws IOException {
+        List<Path> files = new ArrayList<>();
+        Files.walkFileTree(root, new SimpleFileVisitor<>() {
+            @Override
+            public FileVisitResult preVisitDirectory(Path directory, BasicFileAttributes attributes)
+                    throws IOException {
+                if (directory.equals(root)) {
+                    return FileVisitResult.CONTINUE;
+                }
+                if (directory.getFileName().toString().equals(".git")) {
+                    return FileVisitResult.SKIP_SUBTREE;
+                }
+
+                GitPathKey path = GitPathKey.fromNativePath(root, directory);
+                if (selection.submodules().contains(path)) {
+                    if (isGitRepository(directory)) {
+                        files.addAll(loadFromGit(directory));
+                    }
+                    return FileVisitResult.SKIP_SUBTREE;
+                }
+                if (!selection.directories().contains(path)) {
+                    return FileVisitResult.SKIP_SUBTREE;
+                }
+                return FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            public FileVisitResult visitFile(Path file, BasicFileAttributes attributes) throws IOException {
+                GitPathKey path = GitPathKey.fromNativePath(root, file);
+                boolean isScannableFile = attributes.isRegularFile()
+                        || (attributes.isSymbolicLink() && Files.isRegularFile(file));
+                if (selection.files().contains(path) && isScannableFile) {
+                    files.add(file.toAbsolutePath().normalize());
+                }
+                return FileVisitResult.CONTINUE;
+            }
+        });
+        return files;
     }
 
     private List<Path> loadFromFileSystem(Path root) throws IOException {
@@ -141,5 +234,11 @@ public class RepositoryFileLoader {
             }
         });
         return files;
+    }
+
+    private record GitSelection(
+            Set<GitPathKey> files,
+            Set<GitPathKey> directories,
+            Set<GitPathKey> submodules) {
     }
 }

--- a/common/src/main/java/com/github/exadmin/cyberferret/utils/RepositoryFileLoader.java
+++ b/common/src/main/java/com/github/exadmin/cyberferret/utils/RepositoryFileLoader.java
@@ -1,0 +1,145 @@
+package com.github.exadmin.cyberferret.utils;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+public class RepositoryFileLoader {
+    private final List<String> gitCommand;
+
+    public RepositoryFileLoader() {
+        this(List.of("git"));
+    }
+
+    RepositoryFileLoader(List<String> gitCommand) {
+        this.gitCommand = List.copyOf(gitCommand);
+    }
+
+    public List<Path> load(Path root) throws IOException {
+        Path normalizedRoot = root.toAbsolutePath().normalize();
+        if (isGitRepository(normalizedRoot)) {
+            return loadFromGit(normalizedRoot);
+        }
+        return loadFromFileSystem(normalizedRoot);
+    }
+
+    public boolean isGitRepository(Path root) {
+        Path gitEntry = root.toAbsolutePath().normalize().resolve(".git");
+        return Files.isRegularFile(gitEntry)
+                || Files.isRegularFile(gitEntry.resolve("config"));
+    }
+
+    private List<Path> loadFromGit(Path root) throws IOException {
+        Process process;
+        try {
+            List<String> command = new ArrayList<>(gitCommand);
+            command.addAll(List.of(
+                    "-C",
+                    root.toString(),
+                    "ls-files",
+                    "--cached",
+                    "--others",
+                    "--exclude-standard",
+                    "-z"));
+            process = new ProcessBuilder(command).start();
+        } catch (IOException ex) {
+            throw new IOException("Cannot start Git to list repository files", ex);
+        }
+
+        int exitCode;
+        byte[] output;
+        byte[] errorOutput;
+        try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
+            Future<byte[]> outputFuture = executor.submit(() -> process.getInputStream().readAllBytes());
+            Future<byte[]> errorFuture = executor.submit(() -> process.getErrorStream().readAllBytes());
+            try {
+                exitCode = process.waitFor();
+                output = readProcessOutput(outputFuture);
+                errorOutput = readProcessOutput(errorFuture);
+            } catch (InterruptedException ex) {
+                process.destroyForcibly();
+                Thread.currentThread().interrupt();
+                throw new IOException("Interrupted while listing Git repository files", ex);
+            }
+        }
+
+        if (exitCode != 0) {
+            String message = new String(errorOutput, StandardCharsets.UTF_8).trim();
+            throw new IOException("Cannot list Git repository files: " + message);
+        }
+
+        List<Path> files = new ArrayList<>();
+        int entryStart = 0;
+        for (int index = 0; index < output.length; index++) {
+            if (output[index] != 0) {
+                continue;
+            }
+            addGitPath(root, output, entryStart, index, files);
+            entryStart = index + 1;
+        }
+        return files;
+    }
+
+    private byte[] readProcessOutput(Future<byte[]> outputFuture) throws IOException, InterruptedException {
+        try {
+            return outputFuture.get();
+        } catch (ExecutionException ex) {
+            throw new IOException("Cannot read Git process output", ex.getCause());
+        }
+    }
+
+    private void addGitPath(
+            Path root,
+            byte[] output,
+            int entryStart,
+            int entryEnd,
+            List<Path> files) throws IOException {
+        if (entryStart == entryEnd) {
+            return;
+        }
+        String relativePath = new String(
+                output,
+                entryStart,
+                entryEnd - entryStart,
+                StandardCharsets.UTF_8);
+        Path file = root.resolve(relativePath).normalize();
+        if (file.startsWith(root) && Files.isRegularFile(file)) {
+            files.add(file);
+        } else if (file.startsWith(root)
+                && Files.isDirectory(file)
+                && isGitRepository(file)) {
+            files.addAll(loadFromGit(file));
+        }
+    }
+
+    private List<Path> loadFromFileSystem(Path root) throws IOException {
+        List<Path> files = new ArrayList<>();
+        Files.walkFileTree(root, new SimpleFileVisitor<>() {
+            @Override
+            public FileVisitResult preVisitDirectory(Path directory, BasicFileAttributes attributes) {
+                if (directory.getFileName().toString().equals(".git")) {
+                    return FileVisitResult.SKIP_SUBTREE;
+                }
+                return FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            public FileVisitResult visitFile(Path file, BasicFileAttributes attributes) {
+                if (attributes.isRegularFile()) {
+                    files.add(file.toAbsolutePath().normalize());
+                }
+                return FileVisitResult.CONTINUE;
+            }
+        });
+        return files;
+    }
+}

--- a/common/src/test/java/com/github/exadmin/cyberferret/async/RunnableScannerGitFailureTests.java
+++ b/common/src/test/java/com/github/exadmin/cyberferret/async/RunnableScannerGitFailureTests.java
@@ -1,0 +1,46 @@
+package com.github.exadmin.cyberferret.async;
+
+import com.github.exadmin.cyberferret.model.FoundItemsContainer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class RunnableScannerGitFailureTests {
+    @TempDir
+    Path tempDir;
+
+    @Test
+    public void guiMode_reportsGitEnumerationFailure() throws Exception {
+        Path repository = tempDir.resolve("repository");
+        Files.createDirectories(repository.resolve(".git"));
+        Files.writeString(
+                repository.resolve(".git/config"),
+                "[invalid",
+                StandardCharsets.UTF_8);
+
+        List<CallbackMessage> messages = new ArrayList<>();
+        RunnableScanner scanner = new RunnableScanner(false);
+        scanner.setDirToScan(repository.toString());
+        scanner.setFoundItemsContainer(new FoundItemsContainer());
+        scanner.setSignaturesMap(Map.of("test", Pattern.compile("secret")));
+        scanner.setFxCallback((type, message) -> messages.add(new CallbackMessage(type, message)));
+
+        scanner.run();
+
+        assertTrue(messages.stream().anyMatch(message ->
+                message.type() == FxCallback.FxCallbackType.ERROR
+                        && message.text().contains("Cannot list Git repository files")));
+    }
+
+    private record CallbackMessage(FxCallback.FxCallbackType type, String text) {
+    }
+}

--- a/common/src/test/java/com/github/exadmin/cyberferret/async/RunnableScannerGitIgnoreTests.java
+++ b/common/src/test/java/com/github/exadmin/cyberferret/async/RunnableScannerGitIgnoreTests.java
@@ -29,6 +29,9 @@ public class RunnableScannerGitIgnoreTests {
         Path repository = tempDir.resolve("repository");
         Files.createDirectories(repository);
         runGit(repository, "init");
+        Path emptyExcludesFile = tempDir.resolve("empty-global-excludes");
+        Files.writeString(emptyExcludesFile, "", StandardCharsets.UTF_8);
+        runGit(repository, "config", "core.excludesFile", emptyExcludesFile.toString());
 
         Path untrackedSource = repository.resolve("NewSource.java");
         Path gitIgnored = repository.resolve("ignored.txt");

--- a/common/src/test/java/com/github/exadmin/cyberferret/async/RunnableScannerGitIgnoreTests.java
+++ b/common/src/test/java/com/github/exadmin/cyberferret/async/RunnableScannerGitIgnoreTests.java
@@ -1,0 +1,127 @@
+package com.github.exadmin.cyberferret.async;
+
+import com.github.exadmin.cyberferret.model.FoundItemsContainer;
+import com.github.exadmin.cyberferret.model.FoundPathItem;
+import com.github.exadmin.cyberferret.model.ItemType;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+public class RunnableScannerGitIgnoreTests {
+    @TempDir
+    Path tempDir;
+
+    @Test
+    public void guiMode_scansUntrackedFilesButSkipsGitIgnoredFiles() throws Exception {
+        Path repository = tempDir.resolve("repository");
+        Files.createDirectories(repository);
+        runGit(repository, "init");
+
+        Path untrackedSource = repository.resolve("NewSource.java");
+        Path gitIgnored = repository.resolve("ignored.txt");
+        Path locallyExcluded = repository.resolve("local.secret");
+        Files.writeString(untrackedSource, "secret", StandardCharsets.UTF_8);
+        Files.writeString(gitIgnored, "secret", StandardCharsets.UTF_8);
+        Files.writeString(locallyExcluded, "secret", StandardCharsets.UTF_8);
+        Files.writeString(repository.resolve(".gitignore"), "ignored.txt\n", StandardCharsets.UTF_8);
+        Files.writeString(
+                repository.resolve(".git/info/exclude"),
+                "*.secret\n",
+                StandardCharsets.UTF_8);
+
+        FoundItemsContainer foundItemsContainer = new FoundItemsContainer();
+        RunnableScanner scanner = new RunnableScanner(false);
+        scanner.setDirToScan(repository.toString());
+        scanner.setFoundItemsContainer(foundItemsContainer);
+        scanner.setSignaturesMap(Map.of("test", Pattern.compile("secret")));
+        scanner.run();
+
+        Set<Path> scannedFiles = foundItemsContainer.getFoundItemsCopy().stream()
+                .filter(item -> item.getType() == ItemType.FILE)
+                .map(FoundPathItem::getFilePath)
+                .collect(Collectors.toSet());
+        assertTrue(scannedFiles.contains(untrackedSource.toAbsolutePath().normalize()));
+        assertFalse(scannedFiles.contains(gitIgnored.toAbsolutePath().normalize()));
+        assertFalse(scannedFiles.contains(locallyExcluded.toAbsolutePath().normalize()));
+        assertTrue(scanner.isAnySignatureFound());
+    }
+
+    @Test
+    public void guiMode_keepsEmptyDirectoriesOutsideGitRepositories() throws Exception {
+        Path directory = tempDir.resolve("empty-directory");
+        Files.createDirectories(directory);
+
+        FoundItemsContainer foundItemsContainer = new FoundItemsContainer();
+        RunnableScanner scanner = createScanner(directory, foundItemsContainer);
+
+        scanner.run();
+
+        assertEquals(1, foundItemsContainer.getFoundItemsSize());
+        FoundPathItem rootItem = foundItemsContainer.getFoundItemsCopy().getFirst();
+        assertEquals(ItemType.DIRECTORY, rootItem.getType());
+        assertEquals(directory.toAbsolutePath().normalize(), rootItem.getFilePath());
+    }
+
+    @Test
+    public void guiMode_keepsSymbolicLinksOutsideGitRepositories() throws Exception {
+        Path directory = tempDir.resolve("directory-with-link");
+        Files.createDirectories(directory);
+        Path target = directory.resolve("target.txt");
+        Path symbolicLink = directory.resolve("link.txt");
+        Files.writeString(target, "content", StandardCharsets.UTF_8);
+        try {
+            Files.createSymbolicLink(symbolicLink, target.getFileName());
+        } catch (UnsupportedOperationException | IOException | SecurityException ex) {
+            assumeTrue(false, "Symbolic links are not available: " + ex.getMessage());
+        }
+
+        FoundItemsContainer foundItemsContainer = new FoundItemsContainer();
+        RunnableScanner scanner = createScanner(directory, foundItemsContainer);
+
+        scanner.run();
+
+        Set<Path> scannedFiles = foundItemsContainer.getFoundItemsCopy().stream()
+                .filter(item -> item.getType() == ItemType.FILE)
+                .map(FoundPathItem::getFilePath)
+                .collect(Collectors.toSet());
+        assertTrue(scannedFiles.contains(symbolicLink.toAbsolutePath().normalize()));
+    }
+
+    private static RunnableScanner createScanner(
+            Path directory,
+            FoundItemsContainer foundItemsContainer) {
+        RunnableScanner scanner = new RunnableScanner(false);
+        scanner.setDirToScan(directory.toString());
+        scanner.setFoundItemsContainer(foundItemsContainer);
+        scanner.setSignaturesMap(Map.of("test", Pattern.compile("secret")));
+        return scanner;
+    }
+
+    private static void runGit(Path repository, String... arguments) throws Exception {
+        String[] command = new String[arguments.length + 3];
+        command[0] = "git";
+        command[1] = "-C";
+        command[2] = repository.toString();
+        System.arraycopy(arguments, 0, command, 3, arguments.length);
+
+        Process process = new ProcessBuilder(command).redirectErrorStream(true).start();
+        String output = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+        int exitCode = process.waitFor();
+        if (exitCode != 0) {
+            throw new IllegalStateException("Git command failed: " + output);
+        }
+    }
+}

--- a/common/src/test/java/com/github/exadmin/cyberferret/utils/RepositoryFileLoaderEdgeCaseTests.java
+++ b/common/src/test/java/com/github/exadmin/cyberferret/utils/RepositoryFileLoaderEdgeCaseTests.java
@@ -151,6 +151,9 @@ public class RepositoryFileLoaderEdgeCaseTests {
         Path repository = tempDir.resolve(directoryName);
         Files.createDirectories(repository);
         runGit(repository, "init");
+        Path emptyExcludesFile = tempDir.resolve("empty-global-excludes");
+        Files.writeString(emptyExcludesFile, "", StandardCharsets.UTF_8);
+        runGit(repository, "config", "core.excludesFile", emptyExcludesFile.toString());
         return repository;
     }
 

--- a/common/src/test/java/com/github/exadmin/cyberferret/utils/RepositoryFileLoaderEdgeCaseTests.java
+++ b/common/src/test/java/com/github/exadmin/cyberferret/utils/RepositoryFileLoaderEdgeCaseTests.java
@@ -1,0 +1,208 @@
+package com.github.exadmin.cyberferret.utils;
+
+import com.github.exadmin.cyberferret.async.RunnableScanner;
+import com.github.exadmin.cyberferret.model.FoundItemsContainer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+public class RepositoryFileLoaderEdgeCaseTests {
+    @TempDir
+    Path tempDir;
+
+    @Test
+    public void load_doesNotRecurseIntoTrackedSymlinkToExternalGitRepository() throws Exception {
+        Path externalRepository = initializeRepository("external-repository");
+        Files.writeString(
+                externalRepository.resolve("external-secret.txt"),
+                "secret",
+                StandardCharsets.UTF_8);
+
+        Path repository = initializeRepository("repository");
+        Path linkedRepository = repository.resolve("linked-repository");
+        try {
+            Files.createSymbolicLink(linkedRepository, externalRepository);
+        } catch (UnsupportedOperationException | IOException | SecurityException ex) {
+            assumeTrue(false, "Symbolic links are not available: " + ex.getMessage());
+        }
+        runGit(repository, "add", "linked-repository");
+
+        List<Path> files = new RepositoryFileLoader().load(repository);
+
+        assertFalse(files.stream().anyMatch(path -> path.startsWith(linkedRepository)));
+    }
+
+    @Test
+    public void load_keepsTrackedSymlinkToRegularFile() throws Exception {
+        Path externalFile = tempDir.resolve("external-tracked.txt");
+        Files.writeString(externalFile, "secret", StandardCharsets.UTF_8);
+        Path repository = initializeRepository("tracked-file-symlink");
+        Path symbolicLink = createSymbolicLink(repository.resolve("linked.txt"), externalFile);
+        runGit(repository, "add", "linked.txt");
+
+        List<Path> files = new RepositoryFileLoader().load(repository);
+
+        assertTrue(files.contains(symbolicLink.toAbsolutePath().normalize()));
+    }
+
+    @Test
+    public void load_keepsUntrackedSymlinkToRegularFile() throws Exception {
+        Path externalFile = tempDir.resolve("external-untracked.txt");
+        Files.writeString(externalFile, "secret", StandardCharsets.UTF_8);
+        Path repository = initializeRepository("untracked-file-symlink");
+        Path symbolicLink = createSymbolicLink(repository.resolve("linked.txt"), externalFile);
+
+        List<Path> files = new RepositoryFileLoader().load(repository);
+
+        assertTrue(files.contains(symbolicLink.toAbsolutePath().normalize()));
+    }
+
+    @Test
+    public void load_keepsTrackedUnixPathWithInvalidUtf8Bytes() throws Exception {
+        assumeUnixFileNames();
+        Path repository = initializeRepository("tracked-invalid-utf8");
+        runShell(
+                repository,
+                "name=$(printf 'tracked-\\377.txt'); printf 'secret' > \"$name\"; git add -- \"$name\"");
+        Path invalidUtf8File = findInvalidUtf8Path(repository);
+
+        List<Path> files = new RepositoryFileLoader().load(repository);
+
+        assertTrue(files.contains(invalidUtf8File));
+    }
+
+    @Test
+    public void load_keepsUntrackedUnixPathWithInvalidUtf8Bytes() throws Exception {
+        assumeUnixFileNames();
+        Path repository = initializeRepository("untracked-invalid-utf8");
+        runShell(repository, "name=$(printf 'untracked-\\377.txt'); printf 'secret' > \"$name\"");
+        Path invalidUtf8File = findInvalidUtf8Path(repository);
+
+        List<Path> files = new RepositoryFileLoader().load(repository);
+
+        assertTrue(files.contains(invalidUtf8File));
+    }
+
+    @Test
+    public void load_keepsUntrackedUnixPathContainingTab() throws Exception {
+        assumeUnixFileNames();
+        Path repository = initializeRepository("untracked-tab");
+        Path file = repository.resolve("before\tafter.txt");
+        Path ignoredSuffix = repository.resolve("after.txt");
+        Files.writeString(file, "secret", StandardCharsets.UTF_8);
+        Files.writeString(ignoredSuffix, "secret", StandardCharsets.UTF_8);
+        Files.writeString(repository.resolve(".gitignore"), "after.txt\n", StandardCharsets.UTF_8);
+
+        List<Path> files = new RepositoryFileLoader().load(repository);
+
+        assertTrue(files.contains(file.toAbsolutePath().normalize()));
+        assertFalse(files.contains(ignoredSuffix.toAbsolutePath().normalize()));
+    }
+
+    @Test
+    public void load_skipsIgnoredUnixPathWithInvalidUtf8Bytes() throws Exception {
+        assumeUnixFileNames();
+        Path repository = initializeRepository("ignored-invalid-utf8");
+        runShell(
+                repository,
+                "name=$(printf 'ignored-\\377.txt'); printf 'secret' > \"$name\"; "
+                        + "printf '%s\\n' \"$name\" > .gitignore");
+        Path invalidUtf8File = findInvalidUtf8Path(repository);
+
+        List<Path> files = new RepositoryFileLoader().load(repository);
+
+        assertFalse(files.contains(invalidUtf8File));
+    }
+
+    @Test
+    public void guiMode_scansTrackedUnixPathWithInvalidUtf8Bytes() throws Exception {
+        assumeUnixFileNames();
+        Path repository = initializeRepository("scanner-invalid-utf8");
+        runShell(
+                repository,
+                "name=$(printf 'tracked-\\377.txt'); printf 'secret' > \"$name\"; git add -- \"$name\"");
+
+        FoundItemsContainer foundItemsContainer = new FoundItemsContainer();
+        RunnableScanner scanner = new RunnableScanner(false);
+        scanner.setDirToScan(repository.toString());
+        scanner.setFoundItemsContainer(foundItemsContainer);
+        scanner.setSignaturesMap(Map.of("test", Pattern.compile("secret")));
+
+        scanner.run();
+
+        assertTrue(scanner.isAnySignatureFound());
+    }
+
+    private Path initializeRepository(String directoryName) throws Exception {
+        Path repository = tempDir.resolve(directoryName);
+        Files.createDirectories(repository);
+        runGit(repository, "init");
+        return repository;
+    }
+
+    private static void assumeUnixFileNames() {
+        assumeFalse(
+                System.getProperty("os.name", "").toLowerCase(Locale.ROOT).contains("win"),
+                "Invalid UTF-8 filename bytes are a Unix-specific case");
+        assumeTrue(Files.isExecutable(Path.of("/bin/sh")), "/bin/sh is required for this Unix-specific test");
+    }
+
+    private static Path findInvalidUtf8Path(Path repository) throws IOException {
+        try (Stream<Path> paths = Files.list(repository)) {
+            return paths
+                    .filter(path -> path.toUri().getRawPath().toUpperCase(Locale.ROOT).contains("%FF"))
+                    .findFirst()
+                    .orElseThrow(() -> new IOException("Cannot find the invalid UTF-8 test path"));
+        }
+    }
+
+    private static Path createSymbolicLink(Path link, Path target) {
+        try {
+            return Files.createSymbolicLink(link, target);
+        } catch (UnsupportedOperationException | IOException | SecurityException ex) {
+            assumeTrue(false, "Symbolic links are not available: " + ex.getMessage());
+            throw new IllegalStateException(ex);
+        }
+    }
+
+    private static void runShell(Path directory, String script) throws Exception {
+        Process process = new ProcessBuilder("/bin/sh", "-c", script)
+                .directory(directory.toFile())
+                .redirectErrorStream(true)
+                .start();
+        String output = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+        int exitCode = process.waitFor();
+        if (exitCode != 0) {
+            throw new IllegalStateException("Shell command failed: " + output);
+        }
+    }
+
+    private static void runGit(Path repository, String... arguments) throws Exception {
+        String[] command = new String[arguments.length + 3];
+        command[0] = "git";
+        command[1] = "-C";
+        command[2] = repository.toString();
+        System.arraycopy(arguments, 0, command, 3, arguments.length);
+
+        Process process = new ProcessBuilder(command).redirectErrorStream(true).start();
+        String output = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+        int exitCode = process.waitFor();
+        if (exitCode != 0) {
+            throw new IllegalStateException("Git command failed: " + output);
+        }
+    }
+}

--- a/common/src/test/java/com/github/exadmin/cyberferret/utils/RepositoryFilesTests.java
+++ b/common/src/test/java/com/github/exadmin/cyberferret/utils/RepositoryFilesTests.java
@@ -1,0 +1,169 @@
+package com.github.exadmin.cyberferret.utils;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class RepositoryFilesTests {
+    @TempDir
+    Path tempDir;
+
+    @Test
+    public void load_keepsTrackedAndUntrackedFilesButSkipsStandardGitExclusions() throws Exception {
+        Path repository = initializeRepository();
+        Path trackedIgnoredByPattern = write(repository, "tracked.log");
+        runGit(repository, "add", "tracked.log");
+
+        Path untrackedSource = write(repository, "NewSource.java");
+        Path gitIgnored = write(repository, "ignored.log");
+        Path locallyExcluded = write(repository, "local.secret");
+        Files.writeString(repository.resolve(".gitignore"), "*.log\n", StandardCharsets.UTF_8);
+        Files.writeString(
+                repository.resolve(".git/info/exclude"),
+                "*.secret\n",
+                StandardCharsets.UTF_8);
+
+        RepositoryFileLoader loader = new RepositoryFileLoader();
+        List<Path> files = loader.load(repository);
+
+        assertTrue(loader.isGitRepository(repository));
+        assertTrue(files.contains(trackedIgnoredByPattern));
+        assertTrue(files.contains(untrackedSource));
+        assertFalse(files.contains(gitIgnored));
+        assertFalse(files.contains(locallyExcluded));
+    }
+
+    @Test
+    public void load_honorsNegatedGitIgnoreRules() throws Exception {
+        Path repository = initializeRepository();
+        Files.createDirectories(repository.resolve("generated"));
+        Path ignored = write(repository, "generated/ignored.txt");
+        Path included = write(repository, "generated/included.txt");
+        Files.writeString(
+                repository.resolve(".gitignore"),
+                "generated/*\n!generated/included.txt\n",
+                StandardCharsets.UTF_8);
+
+        List<Path> files = new RepositoryFileLoader().load(repository);
+
+        assertFalse(files.contains(ignored));
+        assertTrue(files.contains(included));
+    }
+
+    @Test
+    public void load_walksAllFilesOutsideGitRepositories() throws IOException {
+        Path directory = tempDir.resolve("directory");
+        Files.createDirectories(directory.resolve("nested"));
+        Path rootFile = write(directory, "root.txt");
+        Path nestedFile = write(directory, "nested/file.txt");
+
+        RepositoryFileLoader loader = new RepositoryFileLoader();
+        List<Path> files = loader.load(directory);
+
+        assertFalse(loader.isGitRepository(directory));
+        assertTrue(files.contains(rootFile));
+        assertTrue(files.contains(nestedFile));
+    }
+
+    @Test
+    public void load_doesNotMixSuccessfulGitWarningsIntoFilePaths() throws IOException {
+        Path repository = tempDir.resolve("repository-with-warning");
+        Files.createDirectories(repository.resolve(".git"));
+        Files.writeString(repository.resolve(".git/config"), "[core]\n", StandardCharsets.UTF_8);
+        Path sourceFile = write(repository, "Source.java");
+
+        String javaExecutable = Path.of(
+                System.getProperty("java.home"),
+                "bin",
+                System.getProperty("os.name").startsWith("Windows") ? "java.exe" : "java")
+                .toString();
+        RepositoryFileLoader loader = new RepositoryFileLoader(List.of(
+                javaExecutable,
+                "-cp",
+                System.getProperty("java.class.path"),
+                GitWithWarning.class.getName()));
+
+        List<Path> files = loader.load(repository);
+
+        assertTrue(files.contains(sourceFile));
+    }
+
+    @Test
+    public void load_scansCheckedOutSubmodulesWithTheirOwnGitExclusions() throws Exception {
+        Path submoduleSource = initializeRepository("submodule-source");
+        write(submoduleSource, "Tracked.java");
+        runGit(submoduleSource, "add", "Tracked.java");
+        runGit(submoduleSource, "-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "-m", "init");
+
+        Path repository = initializeRepository("parent-repository");
+        runGit(
+                repository,
+                "-c",
+                "protocol.file.allow=always",
+                "submodule",
+                "add",
+                submoduleSource.toString(),
+                "modules/library");
+
+        Path submodule = repository.resolve("modules/library");
+        Path trackedSource = submodule.resolve("Tracked.java").toAbsolutePath().normalize();
+        Path untrackedSource = write(submodule, "NewSource.java");
+        Path ignoredFile = write(submodule, "ignored.txt");
+        Files.writeString(submodule.resolve(".gitignore"), "ignored.txt\n", StandardCharsets.UTF_8);
+
+        List<Path> files = new RepositoryFileLoader().load(repository);
+
+        assertTrue(files.contains(trackedSource));
+        assertTrue(files.contains(untrackedSource));
+        assertFalse(files.contains(ignoredFile));
+    }
+
+    private Path initializeRepository() throws Exception {
+        return initializeRepository("repository");
+    }
+
+    private Path initializeRepository(String directoryName) throws Exception {
+        Path repository = tempDir.resolve(directoryName);
+        Files.createDirectories(repository);
+        runGit(repository, "init");
+        return repository;
+    }
+
+    private static Path write(Path root, String relativePath) throws IOException {
+        Path path = root.resolve(relativePath);
+        Files.writeString(path, "content", StandardCharsets.UTF_8);
+        return path.toAbsolutePath().normalize();
+    }
+
+    private static void runGit(Path repository, String... arguments) throws Exception {
+        String[] command = new String[arguments.length + 3];
+        command[0] = "git";
+        command[1] = "-C";
+        command[2] = repository.toString();
+        System.arraycopy(arguments, 0, command, 3, arguments.length);
+
+        Process process = new ProcessBuilder(command).redirectErrorStream(true).start();
+        String output = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+        int exitCode = process.waitFor();
+        if (exitCode != 0) {
+            throw new IllegalStateException("Git command failed: " + output);
+        }
+    }
+
+    public static class GitWithWarning {
+        public static void main(String[] arguments) throws Exception {
+            System.err.println("Git warning");
+            System.err.flush();
+            Thread.sleep(50);
+            System.out.write("Source.java\0".getBytes(StandardCharsets.UTF_8));
+        }
+    }
+}

--- a/common/src/test/java/com/github/exadmin/cyberferret/utils/RepositoryFilesTests.java
+++ b/common/src/test/java/com/github/exadmin/cyberferret/utils/RepositoryFilesTests.java
@@ -59,6 +59,24 @@ public class RepositoryFilesTests {
     }
 
     @Test
+    public void load_honorsConfiguredExcludesFile() throws Exception {
+        Path repository = initializeRepository();
+        Path excluded = write(repository, "generated.cache");
+        Path included = write(repository, "Source.java");
+        Path excludesFile = tempDir.resolve("configured-excludes");
+        Files.writeString(excludesFile, "*.cache\n", StandardCharsets.UTF_8);
+        RepositoryFileLoader loader = new RepositoryFileLoader(List.of(
+                "git",
+                "-c",
+                "core.excludesFile=" + excludesFile));
+
+        List<Path> files = loader.load(repository);
+
+        assertFalse(files.contains(excluded));
+        assertTrue(files.contains(included));
+    }
+
+    @Test
     public void load_walksAllFilesOutsideGitRepositories() throws IOException {
         Path directory = tempDir.resolve("directory");
         Files.createDirectories(directory.resolve("nested"));
@@ -114,6 +132,7 @@ public class RepositoryFilesTests {
                 "modules/library");
 
         Path submodule = repository.resolve("modules/library");
+        isolateGlobalExcludes(submodule);
         Path trackedSource = submodule.resolve("Tracked.java").toAbsolutePath().normalize();
         Path untrackedSource = write(submodule, "NewSource.java");
         Path ignoredFile = write(submodule, "ignored.txt");
@@ -134,7 +153,14 @@ public class RepositoryFilesTests {
         Path repository = tempDir.resolve(directoryName);
         Files.createDirectories(repository);
         runGit(repository, "init");
+        isolateGlobalExcludes(repository);
         return repository;
+    }
+
+    private void isolateGlobalExcludes(Path repository) throws Exception {
+        Path emptyExcludesFile = tempDir.resolve("empty-global-excludes");
+        Files.writeString(emptyExcludesFile, "", StandardCharsets.UTF_8);
+        runGit(repository, "config", "core.excludesFile", emptyExcludesFile.toString());
     }
 
     private static Path write(Path root, String relativePath) throws IOException {


### PR DESCRIPTION
## Why

Full repository scans included files excluded by Git, which could report signatures from files that will never be
pushed to the remote repository. See #7.

## What

- Load tracked and non-ignored untracked files through Git standard exclusion rules.
- Honor `.gitignore`, `.git/info/exclude`, global excludes, negation rules, and checked-out submodules.
- Preserve native Unix path bytes so filenames with invalid UTF-8 remain scannable.
- Recurse only into Git entries with gitlink mode (`160000`), preventing tracked directory symlinks from escaping the
  selected repository while retaining symlinks to regular files.
- Preserve staged-file scans and full scans outside Git repositories.
- Document the behavior and add GUI, CLI, loader, symlink, and filename regression tests.

## How to verify

```shell
mvn clean package assembly:single
```
