### PR TITLE
Add automation-safe quick CLI mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,32 @@ After modularization, build artifacts are:
 * JavaFX app: `.\fx\target\cyberferret-fx.jar`
 * CLI app: `.\cli\target\cyberferret-cli.jar`
 
+# Command-line interface
+Set `CYBER_FERRET_PASSWORD` before running the CLI. The existing detailed scan remains available:
+
+```shell
+java -jar ./cli/target/cyberferret-cli.jar PATH_TO_REPOSITORY [PATH_TO_STAGED_FILES_LIST]
+```
+
+Automation can use quick mode, which does not print matched values or file contents:
+
+```shell
+java -jar ./cli/target/cyberferret-cli.jar --mode=quick PATH_TO_REPOSITORY
+```
+
+Quick mode returns `0` when the scan is clean, `1` when it finds a signature, and `2` when the scan cannot complete.
+Use `--cache-dir=PATH` to place the downloaded dictionary in an explicit directory. Without that option, the CLI keeps
+the existing cache behavior based on Git's `core.hooksPath` setting and the current directory.
+
+To prepare one cache snapshot and reuse it for several scans, fetch the dictionary once and then scan offline:
+
+```shell
+java -jar ./cli/target/cyberferret-cli.jar --dictionary-version --cache-dir=PATH
+java -jar ./cli/target/cyberferret-cli.jar --mode=quick --offline --cache-dir=PATH PATH_TO_REPOSITORY
+```
+
+`--dictionary-version` prints exactly one validated version line. An offline scan never refreshes the cached dictionary.
+
 # How to run - Windows version
 Replace "${PATH_TO_JAVA_FX_SDK}" with correct path to JavaFx SDK
 ```shell

--- a/cli/src/main/java/com/github/exadmin/cyberferret/CliArguments.java
+++ b/cli/src/main/java/com/github/exadmin/cyberferret/CliArguments.java
@@ -1,0 +1,101 @@
+package com.github.exadmin.cyberferret;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+record CliArguments(
+        Command command,
+        Path repository,
+        Path stagedFilesList,
+        Path cacheDirectory,
+        boolean offline) {
+    private static final String QUICK_MODE_OPTION = "--mode=quick";
+    private static final String DICTIONARY_VERSION_OPTION = "--dictionary-version";
+    private static final String OFFLINE_OPTION = "--offline";
+    private static final String CACHE_DIRECTORY_PREFIX = "--cache-dir=";
+
+    enum Command {
+        DETAILED_SCAN,
+        QUICK_SCAN,
+        DICTIONARY_VERSION
+    }
+
+    static CliArguments parse(String[] args) {
+        Command command = Command.DETAILED_SCAN;
+        boolean explicitCommand = false;
+        boolean offline = false;
+        Path cacheDirectory = null;
+        List<String> positional = new ArrayList<>();
+
+        for (String argument : args) {
+            if (QUICK_MODE_OPTION.equals(argument)) {
+                if (explicitCommand) throw invalidArguments();
+                command = Command.QUICK_SCAN;
+                explicitCommand = true;
+            } else if (DICTIONARY_VERSION_OPTION.equals(argument)) {
+                if (explicitCommand) throw invalidArguments();
+                command = Command.DICTIONARY_VERSION;
+                explicitCommand = true;
+            } else if (OFFLINE_OPTION.equals(argument)) {
+                if (offline) throw invalidArguments();
+                offline = true;
+            } else if (argument.startsWith(CACHE_DIRECTORY_PREFIX)) {
+                if (cacheDirectory != null) throw invalidArguments();
+                String value = argument.substring(CACHE_DIRECTORY_PREFIX.length());
+                if (value.isEmpty()) throw invalidArguments();
+                cacheDirectory = Path.of(value).normalize();
+            } else if (argument.startsWith("--")) {
+                throw invalidArguments();
+            } else {
+                positional.add(argument);
+            }
+        }
+
+        return switch (command) {
+            case DETAILED_SCAN -> parseDetailed(positional, cacheDirectory, offline);
+            case QUICK_SCAN -> parseQuick(positional, cacheDirectory, offline);
+            case DICTIONARY_VERSION -> parseDictionaryVersion(positional, cacheDirectory, offline);
+        };
+    }
+
+    private static CliArguments parseDetailed(
+            List<String> positional,
+            Path cacheDirectory,
+            boolean offline) {
+        if (positional.size() < 1 || positional.size() > 2 || cacheDirectory != null || offline) {
+            throw invalidArguments();
+        }
+        return new CliArguments(
+                Command.DETAILED_SCAN,
+                Path.of(positional.get(0)).normalize(),
+                positional.size() == 2 ? Path.of(positional.get(1)).normalize() : null,
+                null,
+                false);
+    }
+
+    private static CliArguments parseQuick(
+            List<String> positional,
+            Path cacheDirectory,
+            boolean offline) {
+        if (positional.size() != 1) throw invalidArguments();
+        return new CliArguments(
+                Command.QUICK_SCAN,
+                Path.of(positional.getFirst()).normalize(),
+                null,
+                cacheDirectory,
+                offline);
+    }
+
+    private static CliArguments parseDictionaryVersion(
+            List<String> positional,
+            Path cacheDirectory,
+            boolean offline) {
+        if (!positional.isEmpty() || offline) throw invalidArguments();
+        return new CliArguments(Command.DICTIONARY_VERSION, null, null, cacheDirectory, false);
+    }
+
+    private static IllegalArgumentException invalidArguments() {
+        return new IllegalArgumentException("Invalid command-line arguments.");
+    }
+}

--- a/cli/src/main/java/com/github/exadmin/cyberferret/CyberFerretCLI.java
+++ b/cli/src/main/java/com/github/exadmin/cyberferret/CyberFerretCLI.java
@@ -1,157 +1,124 @@
 package com.github.exadmin.cyberferret;
 
-import com.github.exadmin.cyberferret.async.RunnableCheckOnlineDictionary;
 import com.github.exadmin.cyberferret.async.RunnableScanner;
-import com.github.exadmin.cyberferret.async.RunnableSigsLoader;
 import com.github.exadmin.cyberferret.model.FoundItemsContainer;
-import com.github.exadmin.cyberferret.model.FoundPathItem;
 import com.github.exadmin.cyberferret.utils.*;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.io.InputStream;
+import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 /**
  * This is CLI version of CyberFerret app with focus on quick initialization and run triggered by pre-commit framework.
  */
 public class CyberFerretCLI {
-    private static void printUsage() {
-        String errMsg = """
-                Usage: CyberFerretCLI $PATH_TO_REPOSITORY_TO_SCAN [$PATH_TO_FILE_WITH_LIST_OF_FILES]
-                Also, note that '{}' System Environment variable must be set
-                """;
-        errMsg = ConsoleUtils.format(errMsg, AppConstants.SYS_ENV_VAR_PASSWORD);
-        System.out.println(errMsg);
-    }
-
-    private static void terminateAppWithErrorCode(boolean printUsage) {
-        if (printUsage) printUsage();
-        System.exit(1);
-    }
-
     public static void main(String[] args) {
+        int exitCode = run(args, System.getenv(), System.out, System.err);
+        if (exitCode != 0) System.exit(exitCode);
+    }
+
+    static int run(String[] args, Map<String, String> environment, PrintStream out, PrintStream err) {
+        CliArguments arguments;
         try {
-            _main(args);
-        } catch (Throwable t) {
-            System.out.println("Error: " + t.getMessage());
-            System.exit(1);
+            arguments = CliArguments.parse(args);
+        } catch (RuntimeException exception) {
+            err.println("Invalid command-line arguments.");
+            printUsage(err);
+            return usesAutomationOptions(args) ? 2 : 1;
+        }
+
+        String password = environment.get(AppConstants.SYS_ENV_VAR_PASSWORD);
+        boolean detailed = arguments.command() == CliArguments.Command.DETAILED_SCAN;
+        if (password == null || password.isBlank()) {
+            err.println("Dictionary password is unavailable.");
+            return detailed ? 1 : 2;
+        }
+
+        try {
+            DictionarySession dictionary = DictionarySession.prepare(
+                    arguments.cacheDirectory(),
+                    arguments.offline(),
+                    password);
+            if (arguments.command() == CliArguments.Command.DICTIONARY_VERSION) {
+                out.println(dictionary.dictionaryVersion());
+                return 0;
+            }
+            return runScan(arguments, dictionary, out, err);
+        } catch (DictionarySession.DictionaryException exception) {
+            err.println(exception.getMessage());
+            return detailed ? 1 : 2;
+        } catch (Exception exception) {
+            err.println("CyberFerret could not complete the requested operation.");
+            return detailed ? 1 : 2;
         }
     }
 
-    private static void _main(String[] args) {
-        // Overall logic
-        // Step1: Check required program arguments are set
-        // Step2: Check required system env variables are set
-        // Step3: Ensure actual dictionary is downloaded
-        // Step4: Download dictionary if required
-        // Step5: Decrypt dictionary
-        // Step6: Run check over the git-repository
-
-        String appVer = MiscUtils.loadApplicationVersion();
-        ConsoleUtils.info("CyberFerretCLI version: " + appVer);
-
-        // Step1: Check required program arguments are set
-        if (args.length < 1 || args.length > 2) {
-            ConsoleUtils.error("Unexpected number of command line arguments");
-            terminateAppWithErrorCode(true);
+    private static int runScan(
+            CliArguments arguments,
+            DictionarySession dictionary,
+            PrintStream out,
+            PrintStream err) throws IOException {
+        Path repository = arguments.repository().toAbsolutePath().normalize();
+        boolean detailed = arguments.command() == CliArguments.Command.DETAILED_SCAN;
+        if (!FileUtils.isPathToDir(repository)) {
+            err.println("The repository path is not a readable directory.");
+            return detailed ? 1 : 2;
         }
 
-        final Path repoPathToScan = Path.of(args[0]);
-        if (!FileUtils.isPathToDir(repoPathToScan)) {
-            ConsoleUtils.error("Invalid path to scan directory {}", repoPathToScan);
-            terminateAppWithErrorCode(true);
-        }
-
-        // Step2: Check required system env variable is set
-        final String pass = System.getenv(AppConstants.SYS_ENV_VAR_PASSWORD);
-        if (pass == null || pass.isEmpty()) {
-            ConsoleUtils.error("Environment variable '{}' must be set", AppConstants.SYS_ENV_VAR_PASSWORD);
-            terminateAppWithErrorCode(true);
-        }
-
-        List<Path> stagedFiles = new ArrayList<>();
-        boolean isErrorFound = false;
-        try {
-            if (args.length == 2) {
-                Path stagedFilesListPath = Path.of(args[1]);
-                if (!Files.isRegularFile(stagedFilesListPath)) {
-                    ConsoleUtils.error("Invalid path to files list {}", stagedFilesListPath);
-                    terminateAppWithErrorCode(true);
-                }
-                stagedFiles = loadStagedFiles(repoPathToScan, stagedFilesListPath);
-            } else {
-                stagedFiles = loadFilesFromRepository(repoPathToScan);
+        List<Path> files;
+        if (arguments.stagedFilesList() != null) {
+            Path listPath = arguments.stagedFilesList().toAbsolutePath().normalize();
+            if (!Files.isRegularFile(listPath)) {
+                err.println("The staged-files list is unavailable.");
+                return 1;
             }
-
-            if (stagedFiles.isEmpty()) {
-                ConsoleUtils.error("No files found to scan");
-                return; // do not return error - this may happen when "Commit & Push with Amend is used with no changes in files"
-            }
-        } catch (IOException ex) {
-            ConsoleUtils.error("Error while loading files list. " + ex.getMessage());
-            isErrorFound = true;
-        } finally {
-            if (isErrorFound) {
-                terminateAppWithErrorCode(false);
-            }
+            files = loadStagedFiles(repository, listPath);
+        } else {
+            files = loadFilesFromRepository(repository);
         }
-
-        // Step3: Ensure actual dictionary is downloaded
-        // The dictionarry will be downloaded into Git Global Hook path (only once per 4 hours)
-        RunnableCheckOnlineDictionary dictionaryDownloader = new RunnableCheckOnlineDictionary(true);
-        dictionaryDownloader.setPrintToConsole(true);
-        dictionaryDownloader.run();
-
-        // Step5: Run checks
-        RunnableSigsLoader sigsLoader = new RunnableSigsLoader(true);
-        sigsLoader.setPrintToConsole(true);
-        try {
-            String prefix = GitUtils.getConfigValue("core.hooksPath");
-            if (prefix == null) prefix = "";
-            Path path = Paths.get(prefix.isEmpty() ? "." : prefix, AppConstants.DICTIONARY_FILE_PATH_ENCRYPTED);
-            String encryptedBody = FileUtils.readFile(path);
-            String decryptedBody = PasswordBasedEncryption.decrypt(encryptedBody, pass);
-
-            byte[] bytes = decryptedBody.getBytes(StandardCharsets.UTF_8);
-            InputStream inputStream = new ByteArrayInputStream(bytes);
-            sigsLoader.setInputStream(inputStream);
-            sigsLoader.run();
-        } catch (Exception ex) {
-            ConsoleUtils.error("Error while loading signatures. " + ex.getMessage());
-            terminateAppWithErrorCode(false);
-        }
-
-        // Step6: Run scanner
-        FoundItemsContainer foundItemsContainer = new FoundItemsContainer();
+        if (files.isEmpty()) return 0;
 
         RunnableScanner runnableScanner = new RunnableScanner(true);
-        runnableScanner.setPrintToConsole(true);
-        runnableScanner.setFoundItemsContainer(foundItemsContainer);
-        runnableScanner.setSignaturesMap(sigsLoader.getSignaturesMap());
-        runnableScanner.setAllowedSignaturesMap(sigsLoader.getAllowedSignaturesMap());
-        runnableScanner.setExcludeExtMap(sigsLoader.getExcludeExtsMap());
-        runnableScanner.setDirToScan(repoPathToScan.toString());
-        runnableScanner.setStagedFiles(stagedFiles);
+        runnableScanner.setSilent(!detailed);
+        runnableScanner.setPrintToConsole(detailed);
+        runnableScanner.setRevealFindings(detailed);
+        runnableScanner.setFoundItemsContainer(new FoundItemsContainer());
+        runnableScanner.setSignaturesMap(dictionary.signaturesMap());
+        runnableScanner.setAllowedSignaturesMap(dictionary.allowedSignaturesMap());
+        runnableScanner.setExcludeExtMap(dictionary.excludeExtsMap());
+        runnableScanner.setDirToScan(repository.toString());
+        runnableScanner.setStagedFiles(files);
         runnableScanner.run();
 
-        // Step7: Analyze & Print results
-        for (FoundPathItem foundPathItem : foundItemsContainer.getFoundItemsCopy()) {
-            if (MiscUtils.isNotEmpty(foundPathItem.getFoundString())) {
-                ConsoleUtils.warn("'{}' is found in file '{}' at line {}", foundPathItem.getFoundString(), foundPathItem.getFilePath(), foundPathItem.getLineNumber());
-            }
+        if (runnableScanner.hasOperationalFailure()) {
+            err.println("CyberFerret could not complete the repository scan.");
+            return detailed ? 1 : 2;
         }
-
-        ConsoleUtils.info("Scanning is finished." + (runnableScanner.isAnySignatureFound() ? " Errors were found" : ""));
-
         if (runnableScanner.isAnySignatureFound()) {
-            terminateAppWithErrorCode(false);
+            if (!detailed) out.println("Findings detected");
+            return 1;
         }
+        return 0;
+    }
+
+    private static boolean usesAutomationOptions(String[] args) {
+        for (String argument : args) {
+            if (argument.startsWith("--")) return true;
+        }
+        return false;
+    }
+
+    private static void printUsage(PrintStream stream) {
+        stream.println("Usage:");
+        stream.println("  CyberFerretCLI REPOSITORY [STAGED_FILES_LIST]");
+        stream.println("  CyberFerretCLI --mode=quick [--offline] [--cache-dir=PATH] REPOSITORY");
+        stream.println("  CyberFerretCLI --dictionary-version [--cache-dir=PATH]");
     }
 
     static List<Path> loadStagedFiles(Path rootPathToScan, Path stagedFilesListPath) throws IOException {

--- a/cli/src/main/java/com/github/exadmin/cyberferret/CyberFerretCLI.java
+++ b/cli/src/main/java/com/github/exadmin/cyberferret/CyberFerretCLI.java
@@ -33,8 +33,20 @@ public class CyberFerretCLI {
             return usesAutomationOptions(args) ? 2 : 1;
         }
 
-        String password = environment.get(AppConstants.SYS_ENV_VAR_PASSWORD);
         boolean detailed = arguments.command() == CliArguments.Command.DETAILED_SCAN;
+        List<Path> preloadedFiles = null;
+        if (detailed && arguments.stagedFilesList() != null) {
+            try {
+                preloadedFiles = loadExplicitStagedFiles(arguments, err);
+                if (preloadedFiles == null) return 1;
+                if (preloadedFiles.isEmpty()) return 0;
+            } catch (IOException exception) {
+                err.println("Cannot read the staged-files list.");
+                return 1;
+            }
+        }
+
+        String password = environment.get(AppConstants.SYS_ENV_VAR_PASSWORD);
         if (password == null || password.isBlank()) {
             err.println("Dictionary password is unavailable.");
             return detailed ? 1 : 2;
@@ -49,7 +61,7 @@ public class CyberFerretCLI {
                 out.println(dictionary.dictionaryVersion());
                 return 0;
             }
-            return runScan(arguments, dictionary, out, err);
+            return runScan(arguments, dictionary, preloadedFiles, out, err);
         } catch (DictionarySession.DictionaryException exception) {
             err.println(exception.getMessage());
             return detailed ? 1 : 2;
@@ -62,6 +74,7 @@ public class CyberFerretCLI {
     private static int runScan(
             CliArguments arguments,
             DictionarySession dictionary,
+            List<Path> preloadedFiles,
             PrintStream out,
             PrintStream err) throws IOException {
         Path repository = arguments.repository().toAbsolutePath().normalize();
@@ -72,13 +85,11 @@ public class CyberFerretCLI {
         }
 
         List<Path> files;
-        if (arguments.stagedFilesList() != null) {
-            Path listPath = arguments.stagedFilesList().toAbsolutePath().normalize();
-            if (!Files.isRegularFile(listPath)) {
-                err.println("The staged-files list is unavailable.");
-                return 1;
-            }
-            files = loadStagedFiles(repository, listPath);
+        if (preloadedFiles != null) {
+            files = preloadedFiles;
+        } else if (arguments.stagedFilesList() != null) {
+            files = loadExplicitStagedFiles(arguments, err);
+            if (files == null) return 1;
         } else {
             files = loadFilesFromRepository(repository);
         }
@@ -105,6 +116,20 @@ public class CyberFerretCLI {
             return 1;
         }
         return 0;
+    }
+
+    private static List<Path> loadExplicitStagedFiles(CliArguments arguments, PrintStream err) throws IOException {
+        Path repository = arguments.repository().toAbsolutePath().normalize();
+        if (!FileUtils.isPathToDir(repository)) {
+            err.println("The repository path is not a readable directory.");
+            return null;
+        }
+        Path listPath = arguments.stagedFilesList().toAbsolutePath().normalize();
+        if (!Files.isRegularFile(listPath)) {
+            err.println("The staged-files list is unavailable.");
+            return null;
+        }
+        return loadStagedFiles(repository, listPath);
     }
 
     private static boolean usesAutomationOptions(String[] args) {

--- a/cli/src/test/java/com/github/exadmin/cyberferret/CliArgumentsTests.java
+++ b/cli/src/test/java/com/github/exadmin/cyberferret/CliArgumentsTests.java
@@ -1,0 +1,77 @@
+package com.github.exadmin.cyberferret;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CliArgumentsTests {
+    @Test
+    void parse_keepsDetailedScanWithOnePositionalArgument() {
+        CliArguments arguments = CliArguments.parse(new String[]{"repository"});
+
+        assertEquals(CliArguments.Command.DETAILED_SCAN, arguments.command());
+        assertEquals(Path.of("repository").normalize(), arguments.repository());
+        assertNull(arguments.stagedFilesList());
+        assertNull(arguments.cacheDirectory());
+        assertFalse(arguments.offline());
+    }
+
+    @Test
+    void parse_keepsDetailedScanWithStagedFilesList() {
+        CliArguments arguments = CliArguments.parse(new String[]{"repository", "staged.txt"});
+
+        assertEquals(CliArguments.Command.DETAILED_SCAN, arguments.command());
+        assertEquals(Path.of("staged.txt").normalize(), arguments.stagedFilesList());
+    }
+
+    @Test
+    void parse_readsQuickModeOptions() {
+        CliArguments arguments = CliArguments.parse(new String[]{
+                "--mode=quick",
+                "--offline",
+                "--cache-dir=cache",
+                "repository"
+        });
+
+        assertEquals(CliArguments.Command.QUICK_SCAN, arguments.command());
+        assertEquals(Path.of("repository").normalize(), arguments.repository());
+        assertEquals(Path.of("cache").normalize(), arguments.cacheDirectory());
+        assertTrue(arguments.offline());
+    }
+
+    @Test
+    void parse_readsDictionaryVersionCommand() {
+        CliArguments arguments = CliArguments.parse(new String[]{
+                "--dictionary-version",
+                "--cache-dir=cache"
+        });
+
+        assertEquals(CliArguments.Command.DICTIONARY_VERSION, arguments.command());
+        assertNull(arguments.repository());
+        assertEquals(Path.of("cache").normalize(), arguments.cacheDirectory());
+        assertFalse(arguments.offline());
+    }
+
+    @Test
+    void parse_rejectsInvalidCombinations() {
+        assertThrows(IllegalArgumentException.class, () -> CliArguments.parse(new String[]{}));
+        assertThrows(IllegalArgumentException.class,
+                () -> CliArguments.parse(new String[]{"--mode=quick"}));
+        assertThrows(IllegalArgumentException.class,
+                () -> CliArguments.parse(new String[]{"--dictionary-version", "repository"}));
+        assertThrows(IllegalArgumentException.class,
+                () -> CliArguments.parse(new String[]{"--dictionary-version", "--offline"}));
+        assertThrows(IllegalArgumentException.class,
+                () -> CliArguments.parse(new String[]{"--unknown", "repository"}));
+        assertThrows(IllegalArgumentException.class,
+                () -> CliArguments.parse(new String[]{"--mode=other", "repository"}));
+        assertThrows(IllegalArgumentException.class,
+                () -> CliArguments.parse(new String[]{"--cache-dir=", "repository"}));
+    }
+}

--- a/cli/src/test/java/com/github/exadmin/cyberferret/CyberFerretCLIQuickModeTests.java
+++ b/cli/src/test/java/com/github/exadmin/cyberferret/CyberFerretCLIQuickModeTests.java
@@ -70,6 +70,25 @@ class CyberFerretCLIQuickModeTests {
     }
 
     @Test
+    void quickMode_returnsTwoForIncompleteSignatureSets() throws Exception {
+        Path repository = prepareRepository(SENTINEL);
+        for (String dictionary : new String[]{
+                "VERSION=1.4\n",
+                "VERSION=1.4\nBROKEN(regexp)=[\n",
+                "VERSION=1.4\nSECRET=" + SENTINEL + "\nBROKEN(regexp)=[\n"
+        }) {
+            Path cache = prepareDictionary(dictionary);
+
+            Invocation invocation = invoke("--mode=quick", "--offline", cacheOption(cache), repository.toString());
+
+            assertEquals(2, invocation.exitCode());
+            assertFalse(invocation.stdout().contains(SENTINEL));
+            assertFalse(invocation.stderr().contains(SENTINEL));
+            assertFalse(invocation.stderr().contains(PASSWORD));
+        }
+    }
+
+    @Test
     void dictionaryVersion_printsExactlyOneSafeLine() throws Exception {
         Path cache = prepareDictionary();
 

--- a/cli/src/test/java/com/github/exadmin/cyberferret/CyberFerretCLIQuickModeTests.java
+++ b/cli/src/test/java/com/github/exadmin/cyberferret/CyberFerretCLIQuickModeTests.java
@@ -1,0 +1,150 @@
+package com.github.exadmin.cyberferret;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import javax.crypto.Cipher;
+import javax.crypto.SecretKey;
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.PBEKeySpec;
+import javax.crypto.spec.SecretKeySpec;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.spec.KeySpec;
+import java.util.Base64;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CyberFerretCLIQuickModeTests {
+    private static final String PASSWORD = "test-password";
+    private static final String SENTINEL = "DO_NOT_PRINT_THIS_SECRET";
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void quickMode_returnsZeroForCleanRepository() throws Exception {
+        Path cache = prepareDictionary();
+        Path repository = prepareRepository("ordinary content");
+
+        Invocation invocation = invoke("--mode=quick", "--offline", cacheOption(cache), repository.toString());
+
+        assertEquals(0, invocation.exitCode());
+        assertFalse(invocation.stdout().contains(SENTINEL));
+        assertFalse(invocation.stderr().contains(SENTINEL));
+    }
+
+    @Test
+    void quickMode_returnsOneWithoutRevealingFinding() throws Exception {
+        Path cache = prepareDictionary();
+        Path repository = prepareRepository(SENTINEL);
+
+        Invocation invocation = invoke("--mode=quick", "--offline", cacheOption(cache), repository.toString());
+
+        assertEquals(1, invocation.exitCode());
+        assertTrue(invocation.stdout().contains("Findings detected"));
+        assertFalse(invocation.stdout().contains(SENTINEL));
+        assertFalse(invocation.stderr().contains(SENTINEL));
+    }
+
+    @Test
+    void quickMode_returnsTwoForMissingOfflineDictionary() throws Exception {
+        Path repository = prepareRepository("ordinary content");
+
+        Invocation invocation = invoke(
+                "--mode=quick",
+                "--offline",
+                cacheOption(tempDir.resolve("missing-cache")),
+                repository.toString());
+
+        assertEquals(2, invocation.exitCode());
+        assertFalse(invocation.stdout().contains(PASSWORD));
+        assertFalse(invocation.stderr().contains(PASSWORD));
+    }
+
+    @Test
+    void dictionaryVersion_printsExactlyOneSafeLine() throws Exception {
+        Path cache = prepareDictionary();
+
+        Invocation invocation = invoke("--dictionary-version", cacheOption(cache));
+
+        assertEquals(0, invocation.exitCode());
+        assertEquals("1.4" + System.lineSeparator(), invocation.stdout());
+        assertEquals("", invocation.stderr());
+        assertFalse(invocation.stdout().contains(SENTINEL));
+        assertFalse(invocation.stderr().contains(PASSWORD));
+    }
+
+    @Test
+    void dictionaryVersion_rejectsUnsafeMetadata() throws Exception {
+        Path cache = prepareDictionary("VERSION=unsafe version\nSECRET=" + SENTINEL + "\n");
+
+        Invocation invocation = invoke("--dictionary-version", cacheOption(cache));
+
+        assertEquals(2, invocation.exitCode());
+        assertEquals("", invocation.stdout());
+        assertEquals("Dictionary version is invalid." + System.lineSeparator(), invocation.stderr());
+        assertFalse(invocation.stderr().contains(SENTINEL));
+        assertFalse(invocation.stderr().contains(PASSWORD));
+    }
+
+    private Invocation invoke(String... arguments) {
+        ByteArrayOutputStream stdout = new ByteArrayOutputStream();
+        ByteArrayOutputStream stderr = new ByteArrayOutputStream();
+        int exitCode = CyberFerretCLI.run(
+                arguments,
+                Map.of(AppConstants.SYS_ENV_VAR_PASSWORD, PASSWORD),
+                new PrintStream(stdout, true, StandardCharsets.UTF_8),
+                new PrintStream(stderr, true, StandardCharsets.UTF_8));
+        return new Invocation(
+                exitCode,
+                stdout.toString(StandardCharsets.UTF_8),
+                stderr.toString(StandardCharsets.UTF_8));
+    }
+
+    private Path prepareDictionary() throws Exception {
+        return prepareDictionary("VERSION=1.4\nSECRET=" + SENTINEL + "\n");
+    }
+
+    private Path prepareDictionary(String dictionary) throws Exception {
+        Path cache = tempDir.resolve("cache");
+        Files.createDirectories(cache);
+        Files.writeString(
+                cache.resolve(AppConstants.DICTIONARY_FILE_PATH_ENCRYPTED),
+                encrypt(dictionary, PASSWORD),
+                StandardCharsets.UTF_8);
+        return cache;
+    }
+
+    private Path prepareRepository(String content) throws Exception {
+        Path repository = Files.createTempDirectory(tempDir, "repository-");
+        Files.writeString(repository.resolve("source.txt"), content, StandardCharsets.UTF_8);
+        return repository;
+    }
+
+    private static String cacheOption(Path cache) {
+        return "--cache-dir=" + cache;
+    }
+
+    private static String encrypt(String value, String password) throws Exception {
+        byte[] salt = "bsd87918hediu".getBytes(StandardCharsets.UTF_8);
+        byte[] iv = {0, 2, 3, 4, 5, 4, 3, 2, 1, 0, 1, 2, 3, 4, 5, 0};
+        SecretKeyFactory factory = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA256");
+        KeySpec spec = new PBEKeySpec(password.toCharArray(), salt, 65536, 256);
+        SecretKey temporaryKey = factory.generateSecret(spec);
+        SecretKeySpec secretKey = new SecretKeySpec(temporaryKey.getEncoded(), "AES");
+        Cipher cipher = Cipher.getInstance("AES/CBC/PKCS5Padding");
+        cipher.init(Cipher.ENCRYPT_MODE, secretKey, new IvParameterSpec(iv));
+        return Base64.getEncoder().encodeToString(cipher.doFinal(value.getBytes(StandardCharsets.UTF_8)));
+    }
+
+    private record Invocation(int exitCode, String stdout, String stderr) {
+    }
+}

--- a/cli/src/test/java/com/github/exadmin/cyberferret/CyberFerretCLITests.java
+++ b/cli/src/test/java/com/github/exadmin/cyberferret/CyberFerretCLITests.java
@@ -4,10 +4,13 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -74,5 +77,25 @@ public class CyberFerretCLITests {
         assertEquals(2, files.size());
         assertTrue(files.contains(rootFile.normalize()));
         assertTrue(files.contains(nestedFile.normalize()));
+    }
+
+    @Test
+    public void detailedScan_emptyStagedListDoesNotPrepareDictionary() throws IOException {
+        Path root = tempDir.resolve("repo-empty-staged-list");
+        Files.createDirectories(root);
+        Path listFile = tempDir.resolve("staged-empty.txt");
+        Files.writeString(listFile, "", StandardCharsets.UTF_8);
+        ByteArrayOutputStream stdout = new ByteArrayOutputStream();
+        ByteArrayOutputStream stderr = new ByteArrayOutputStream();
+
+        int exitCode = CyberFerretCLI.run(
+                new String[]{root.toString(), listFile.toString()},
+                Map.of(AppConstants.SYS_ENV_VAR_PASSWORD, "wrong-password"),
+                new PrintStream(stdout, true, StandardCharsets.UTF_8),
+                new PrintStream(stderr, true, StandardCharsets.UTF_8));
+
+        assertEquals(0, exitCode);
+        assertEquals("", stdout.toString(StandardCharsets.UTF_8));
+        assertEquals("", stderr.toString(StandardCharsets.UTF_8));
     }
 }

--- a/common/src/main/java/com/github/exadmin/cyberferret/DictionarySession.java
+++ b/common/src/main/java/com/github/exadmin/cyberferret/DictionarySession.java
@@ -49,13 +49,30 @@ public final class DictionarySession {
 
         if (!offline) {
             createCacheDirectory(dictionaryPath);
+            downloader.setDownloadedDictionaryValidator(candidatePath -> isValidDictionary(candidatePath, password));
             downloader.run();
+            if (downloader.hasRejectedDownloadedDictionary()) {
+                throw new DictionaryException("Downloaded dictionary is invalid.");
+            }
         }
 
         if (!Files.isRegularFile(dictionaryPath)) {
             throw new DictionaryException("Cached dictionary is unavailable.");
         }
 
+        return loadDictionary(dictionaryPath, password);
+    }
+
+    private static boolean isValidDictionary(Path dictionaryPath, String password) {
+        try {
+            loadDictionary(dictionaryPath, password);
+            return true;
+        } catch (DictionaryException exception) {
+            return false;
+        }
+    }
+
+    private static DictionarySession loadDictionary(Path dictionaryPath, String password) {
         String encryptedBody;
         try {
             encryptedBody = FileUtils.readFile(dictionaryPath);

--- a/common/src/main/java/com/github/exadmin/cyberferret/DictionarySession.java
+++ b/common/src/main/java/com/github/exadmin/cyberferret/DictionarySession.java
@@ -15,6 +15,7 @@ import java.util.Map;
 import java.util.regex.Pattern;
 
 public final class DictionarySession {
+    private static final Pattern VALID_VERSION = Pattern.compile("[A-Za-z0-9][A-Za-z0-9._+\\-]{0,63}");
     private final Map<String, Pattern> signaturesMap;
     private final Map<String, String> allowedSignaturesMap;
     private final Map<String, List<String>> excludeExtsMap;
@@ -25,11 +26,15 @@ public final class DictionarySession {
         allowedSignaturesMap = loader.getAllowedSignaturesMap();
         excludeExtsMap = loader.getExcludeExtsMap();
         String loadedVersion = loader.getDictionaryVersion();
-        dictionaryVersion = loadedVersion == null
+        String normalizedVersion = loadedVersion == null
                 || loadedVersion.isBlank()
                 || "undefined".equalsIgnoreCase(loadedVersion)
                 ? "unknown"
                 : loadedVersion.trim();
+        if (!VALID_VERSION.matcher(normalizedVersion).matches()) {
+            throw new DictionaryException("Dictionary version is invalid.");
+        }
+        dictionaryVersion = normalizedVersion;
     }
 
     public static DictionarySession prepare(Path cacheDirectory, boolean offline, String password) {
@@ -38,6 +43,7 @@ public final class DictionarySession {
         }
 
         RunnableCheckOnlineDictionary downloader = new RunnableCheckOnlineDictionary(true);
+        downloader.setSilent(true);
         downloader.setCacheDirectory(cacheDirectory);
         Path dictionaryPath = downloader.getDictionaryPath();
 
@@ -65,6 +71,7 @@ public final class DictionarySession {
         }
 
         RunnableSigsLoader loader = new RunnableSigsLoader(true);
+        loader.setSilent(true);
         loader.setInputStream(new ByteArrayInputStream(decryptedBody.getBytes(StandardCharsets.UTF_8)));
         try {
             loader._run();

--- a/common/src/main/java/com/github/exadmin/cyberferret/DictionarySession.java
+++ b/common/src/main/java/com/github/exadmin/cyberferret/DictionarySession.java
@@ -1,0 +1,111 @@
+package com.github.exadmin.cyberferret;
+
+import com.github.exadmin.cyberferret.async.RunnableCheckOnlineDictionary;
+import com.github.exadmin.cyberferret.async.RunnableSigsLoader;
+import com.github.exadmin.cyberferret.utils.FileUtils;
+import com.github.exadmin.cyberferret.utils.PasswordBasedEncryption;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+public final class DictionarySession {
+    private final Map<String, Pattern> signaturesMap;
+    private final Map<String, String> allowedSignaturesMap;
+    private final Map<String, List<String>> excludeExtsMap;
+    private final String dictionaryVersion;
+
+    private DictionarySession(RunnableSigsLoader loader) {
+        signaturesMap = loader.getSignaturesMap();
+        allowedSignaturesMap = loader.getAllowedSignaturesMap();
+        excludeExtsMap = loader.getExcludeExtsMap();
+        String loadedVersion = loader.getDictionaryVersion();
+        dictionaryVersion = loadedVersion == null
+                || loadedVersion.isBlank()
+                || "undefined".equalsIgnoreCase(loadedVersion)
+                ? "unknown"
+                : loadedVersion.trim();
+    }
+
+    public static DictionarySession prepare(Path cacheDirectory, boolean offline, String password) {
+        if (password == null || password.isBlank()) {
+            throw new DictionaryException("Dictionary password is unavailable.");
+        }
+
+        RunnableCheckOnlineDictionary downloader = new RunnableCheckOnlineDictionary(true);
+        downloader.setCacheDirectory(cacheDirectory);
+        Path dictionaryPath = downloader.getDictionaryPath();
+
+        if (!offline) {
+            createCacheDirectory(dictionaryPath);
+            downloader.run();
+        }
+
+        if (!Files.isRegularFile(dictionaryPath)) {
+            throw new DictionaryException("Cached dictionary is unavailable.");
+        }
+
+        String encryptedBody;
+        try {
+            encryptedBody = FileUtils.readFile(dictionaryPath);
+        } catch (Exception exception) {
+            throw new DictionaryException("Cannot read the cached dictionary.");
+        }
+
+        String decryptedBody;
+        try {
+            decryptedBody = PasswordBasedEncryption.decrypt(encryptedBody, password);
+        } catch (Exception exception) {
+            throw new DictionaryException("Cannot decrypt the dictionary.");
+        }
+
+        RunnableSigsLoader loader = new RunnableSigsLoader(true);
+        loader.setInputStream(new ByteArrayInputStream(decryptedBody.getBytes(StandardCharsets.UTF_8)));
+        try {
+            loader._run();
+        } catch (Exception exception) {
+            throw new DictionaryException("Cannot parse the dictionary.");
+        }
+        if (!loader.isReady()) {
+            throw new DictionaryException("Cannot parse the dictionary.");
+        }
+        return new DictionarySession(loader);
+    }
+
+    private static void createCacheDirectory(Path dictionaryPath) {
+        Path parent = dictionaryPath.toAbsolutePath().getParent();
+        if (parent == null) return;
+        try {
+            Files.createDirectories(parent);
+        } catch (IOException exception) {
+            throw new DictionaryException("Cannot create the dictionary cache directory.");
+        }
+    }
+
+    public Map<String, Pattern> signaturesMap() {
+        return signaturesMap;
+    }
+
+    public Map<String, String> allowedSignaturesMap() {
+        return allowedSignaturesMap;
+    }
+
+    public Map<String, List<String>> excludeExtsMap() {
+        return excludeExtsMap;
+    }
+
+    public String dictionaryVersion() {
+        return dictionaryVersion;
+    }
+
+    public static final class DictionaryException extends IllegalStateException {
+        public DictionaryException(String message) {
+            super(message);
+        }
+    }
+}

--- a/common/src/main/java/com/github/exadmin/cyberferret/async/ARunnable.java
+++ b/common/src/main/java/com/github/exadmin/cyberferret/async/ARunnable.java
@@ -7,6 +7,7 @@ public abstract class ARunnable extends HandyLogging implements Runnable {
     protected volatile Runnable afterFinished;
     // when running Scanner in CLI mode - no specific data-store to be rendered in FxUI is collected (amy be additional light operations are executed)
     private final boolean isCLIMode;
+    private volatile boolean successful = true;
 
     public ARunnable(boolean isCLIMode) {
         this.isCLIMode = isCLIMode;
@@ -23,15 +24,18 @@ public abstract class ARunnable extends HandyLogging implements Runnable {
 
     @Override
     public final void run()  {
+        successful = true;
         try {
             if (beforeStart != null) beforeStart.run();
             _run();
         } catch (Exception ex) {
+            successful = false;
             logError("Error during scan running", ex);
         } finally {
             try {
                 if (afterFinished != null) afterFinished.run();
             } catch (Exception ex) {
+                successful = false;
                 logError("Error during finishing scan running", ex);
             }
         }
@@ -45,5 +49,9 @@ public abstract class ARunnable extends HandyLogging implements Runnable {
 
     public boolean isCLIMode() {
         return isCLIMode;
+    }
+
+    public boolean isSuccessful() {
+        return successful;
     }
 }

--- a/common/src/main/java/com/github/exadmin/cyberferret/async/RunnableCheckOnlineDictionary.java
+++ b/common/src/main/java/com/github/exadmin/cyberferret/async/RunnableCheckOnlineDictionary.java
@@ -18,10 +18,14 @@ import java.nio.file.StandardCopyOption;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
+import java.util.Objects;
+import java.util.function.Predicate;
 
 public class RunnableCheckOnlineDictionary extends ARunnable {
     private static final Duration DICTIONARY_REFRESH_INTERVAL = Duration.ofHours(4);
     private Path cacheDirectory;
+    private volatile Predicate<Path> downloadedDictionaryValidator = ignored -> true;
+    private volatile boolean rejectedDownloadedDictionary;
 
     public RunnableCheckOnlineDictionary(boolean isCLIMode) {
         super(isCLIMode);
@@ -42,8 +46,17 @@ public class RunnableCheckOnlineDictionary extends ARunnable {
         return Paths.get(prefix, AppConstants.DICTIONARY_FILE_PATH_ENCRYPTED);
     }
 
+    public void setDownloadedDictionaryValidator(Predicate<Path> validator) {
+        downloadedDictionaryValidator = Objects.requireNonNull(validator);
+    }
+
+    public boolean hasRejectedDownloadedDictionary() {
+        return rejectedDownloadedDictionary;
+    }
+
     @Override
     protected void _run() {
+        rejectedDownloadedDictionary = false;
         logInfo("Checking if new online dictionary exists");
 
         Path path = getDictionaryPath();
@@ -89,7 +102,7 @@ public class RunnableCheckOnlineDictionary extends ARunnable {
                 try (InputStream inputStream = responseEntity.getContent()) {
                     Files.copy(inputStream, tempPath, StandardCopyOption.REPLACE_EXISTING);
                 }
-                moveWithReplace(tempPath, savePath.toPath());
+                if (!promoteDownloadedDictionary(tempPath, savePath.toPath())) return;
                 logInfo("File was downloaded successfully and saved in {}", savePath.getAbsoluteFile());
             }
         } catch (IOException ex) {
@@ -113,6 +126,22 @@ public class RunnableCheckOnlineDictionary extends ARunnable {
                 .build();
         request.setConfig(requestConfig);
         return request;
+    }
+
+    protected boolean promoteDownloadedDictionary(Path candidatePath, Path targetPath) throws IOException {
+        boolean valid;
+        try {
+            valid = downloadedDictionaryValidator.test(candidatePath);
+        } catch (RuntimeException exception) {
+            valid = false;
+        }
+        if (!valid) {
+            rejectedDownloadedDictionary = true;
+            logError("Downloaded dictionary failed validation. The cached dictionary was not changed.");
+            return false;
+        }
+        moveWithReplace(candidatePath, targetPath);
+        return true;
     }
 
     private Path createTempFileNearTarget(Path targetPath) throws IOException {

--- a/common/src/main/java/com/github/exadmin/cyberferret/async/RunnableCheckOnlineDictionary.java
+++ b/common/src/main/java/com/github/exadmin/cyberferret/async/RunnableCheckOnlineDictionary.java
@@ -21,19 +21,32 @@ import java.time.Duration;
 
 public class RunnableCheckOnlineDictionary extends ARunnable {
     private static final Duration DICTIONARY_REFRESH_INTERVAL = Duration.ofHours(4);
+    private Path cacheDirectory;
 
     public RunnableCheckOnlineDictionary(boolean isCLIMode) {
         super(isCLIMode);
+    }
+
+    public void setCacheDirectory(Path cacheDirectory) {
+        this.cacheDirectory = cacheDirectory == null ? null : cacheDirectory.toAbsolutePath().normalize();
+    }
+
+    public Path getDictionaryPath() {
+        if (cacheDirectory != null) {
+            return cacheDirectory.resolve(AppConstants.DICTIONARY_FILE_PATH_ENCRYPTED).normalize();
+        }
+
+        String prefix = "";
+        if (isCLIMode()) prefix = GitUtils.getConfigValue("core.hooksPath");
+        if (prefix == null) prefix = "";
+        return Paths.get(prefix, AppConstants.DICTIONARY_FILE_PATH_ENCRYPTED);
     }
 
     @Override
     protected void _run() {
         logInfo("Checking if new online dictionary exists");
 
-        String prefix = "";
-        if (isCLIMode()) prefix = GitUtils.getConfigValue("core.hooksPath");
-        if (prefix == null) prefix = "";
-        Path path = Paths.get(prefix, AppConstants.DICTIONARY_FILE_PATH_ENCRYPTED);
+        Path path = getDictionaryPath();
         File savePath = path.toFile();
 
         if (savePath.exists()) {

--- a/common/src/main/java/com/github/exadmin/cyberferret/async/RunnableScanner.java
+++ b/common/src/main/java/com/github/exadmin/cyberferret/async/RunnableScanner.java
@@ -97,6 +97,7 @@ public class RunnableScanner extends ARunnable {
         }
 
         if (currentSigMap.isEmpty()) {
+            operationalFailure.set(true);
             fxCallback.showMessage(FxCallback.FxCallbackType.ERROR, "Load signatures first. Nothing to scan by.");
             return;
         }

--- a/common/src/main/java/com/github/exadmin/cyberferret/async/RunnableScanner.java
+++ b/common/src/main/java/com/github/exadmin/cyberferret/async/RunnableScanner.java
@@ -30,6 +30,8 @@ public class RunnableScanner extends ARunnable {
     private Map<String, List<String>> excludeExtMap = Map.of();
     private FxCallback fxCallback = (type, message) -> logInfo(message);
     private final AtomicBoolean isAnySignatureFound = new AtomicBoolean(false);
+    private final AtomicBoolean operationalFailure = new AtomicBoolean(false);
+    private boolean revealFindings = true;
     private List<Path> stagedFiles;
 
     public RunnableScanner(boolean isCLIMode) {
@@ -68,9 +70,14 @@ public class RunnableScanner extends ARunnable {
         this.stagedFiles = new ArrayList<>(stagedFiles);
     }
 
+    public void setRevealFindings(boolean revealFindings) {
+        this.revealFindings = revealFindings;
+    }
+
     @Override
     protected void _run() throws IOException {
         isAnySignatureFound.set(false);
+        operationalFailure.set(false);
 
         final String scanDir = dirToScan;
         final FoundItemsContainer itemsContainer = foundItemsContainer;
@@ -131,23 +138,24 @@ public class RunnableScanner extends ARunnable {
             list.forEach(pathItem -> {
                 executor.submit(() -> {
                     numberOfThreadsInProgress.incrementAndGet();
+                    try {
+                        int currentCount = processedItemsCount.incrementAndGet();
+                        int progressRate = currentCount * 100 / totalItemsCount;
+                        int rateToLog = nextRate.updateAndGet(rate -> progressRate > rate ? rate + 10 : rate);
+                        if (progressRate > rateToLog - 10 && isCLIMode()) {
+                            logInfo("Scan rate is {}%", progressRate);
+                        }
 
-                    // update progress rate
-                    int currentCount = processedItemsCount.incrementAndGet();
-                    int progressRate =  currentCount * 100 / totalItemsCount;
-                    int rateToLog = nextRate.updateAndGet(rate -> progressRate > rate ? rate + 10 : rate);
-                    if (progressRate > rateToLog - 10) {
-                        if (isCLIMode()) logInfo("Scan rate is {}%", progressRate);
+                        logDebug("Threads in progress = {}, Scanning for {}",
+                                numberOfThreadsInProgress.get(), pathItem);
+                        scan(pathItem, rootDir, excludeFileModel, itemsContainer,
+                                currentSigMap, currentAllowedSignaturesMap, currentExcludeExtMap);
+                    } catch (RuntimeException exception) {
+                        operationalFailure.set(true);
+                        logError("Error while scanning {}", pathItem, exception);
+                    } finally {
+                        numberOfThreadsInProgress.decrementAndGet();
                     }
-
-
-                    logDebug("Threads in progress = {}, Scanning for {}", numberOfThreadsInProgress.get(), pathItem);
-
-                    // do scan
-                    scan(pathItem, rootDir, excludeFileModel, itemsContainer,
-                            currentSigMap, currentAllowedSignaturesMap, currentExcludeExtMap);
-
-                    numberOfThreadsInProgress.decrementAndGet();
                 });
             });
         }
@@ -173,6 +181,7 @@ public class RunnableScanner extends ARunnable {
                 continue;
             }
             if (!Files.isRegularFile(normalizedFile)) {
+                operationalFailure.set(true);
                 logTrace("Skipping staged path because it is not a regular file {}", normalizedFile);
                 continue;
             }
@@ -199,6 +208,7 @@ public class RunnableScanner extends ARunnable {
                     ? new HashSet<>(repositoryFileLoader.load(rootDir))
                     : Set.of();
         } catch (IOException ex) {
+            operationalFailure.set(true);
             fxCallback.showMessage(
                     FxCallback.FxCallbackType.ERROR,
                     "Cannot enumerate Git repository files: " + ex.getMessage()
@@ -256,6 +266,7 @@ public class RunnableScanner extends ARunnable {
 
             @Override
             public FileVisitResult visitFileFailed(Path file, IOException exc) {
+                operationalFailure.set(true);
                 logError("Error while visiting {}", file);
                 return FileVisitResult.CONTINUE;
             }
@@ -315,6 +326,7 @@ public class RunnableScanner extends ARunnable {
             logTrace("Reading file {}", filePath);
             fileBody = FileUtils.readFile(filePath);
         } catch (IOException ex) {
+            operationalFailure.set(true);
             logError("Error while reading file '{}'. Skipping it.", filePath, ex);
             return;
         }
@@ -342,7 +354,12 @@ public class RunnableScanner extends ARunnable {
 
                 if (!newItem.isAllowedValue() && !newItem.isIgnored()) {
                     isAnySignatureFound.set(true);
-                    logError("Signature '{}' is found in {}:{}", newItem.getFoundString(), filePath, newItem.getLineNumber());
+                    if (revealFindings) {
+                        logError("Signature '{}' is found in {}:{}", newItem.getFoundString(), filePath,
+                                newItem.getLineNumber());
+                    } else {
+                        logError("A signature is found in {}:{}", filePath, newItem.getLineNumber());
+                    }
                 }
 
                 if (!isCLIMode()) foundItemsContainer.addItem(newItem);
@@ -387,5 +404,9 @@ public class RunnableScanner extends ARunnable {
 
     public boolean isAnySignatureFound() {
         return isAnySignatureFound.get();
+    }
+
+    public boolean hasOperationalFailure() {
+        return operationalFailure.get() || !isSuccessful();
     }
 }

--- a/common/src/main/java/com/github/exadmin/cyberferret/async/RunnableSigsLoader.java
+++ b/common/src/main/java/com/github/exadmin/cyberferret/async/RunnableSigsLoader.java
@@ -42,6 +42,10 @@ public class RunnableSigsLoader extends ARunnable {
         return isReady.get();
     }
 
+    public String getDictionaryVersion() {
+        return dictionaryVersion;
+    }
+
     @Override
     public void _run() {
         isReady.set(false);

--- a/common/src/main/java/com/github/exadmin/cyberferret/async/RunnableSigsLoader.java
+++ b/common/src/main/java/com/github/exadmin/cyberferret/async/RunnableSigsLoader.java
@@ -59,6 +59,7 @@ public class RunnableSigsLoader extends ARunnable {
             Map<String, Pattern> regExpTmpMap = new HashMap<>();
             Map<String, String> allowedSignaturesTmpMap = new HashMap<>();
             Map<String, List<String>> excludeExtTmpMap = new HashMap<>();
+            boolean allSignaturesValid = true;
 
             for (Object key : properties.keySet()) {
                 String sigId = key.toString();
@@ -90,8 +91,13 @@ public class RunnableSigsLoader extends ARunnable {
                     // logInfo("Signature with id '{}' = '{}' is marked as allowed.", sigId, expression);
                     allowedSignaturesTmpMap.put(sigId, expression);
                 } else {
-                    compileAndKeep(sigId, expression, regExpTmpMap);
+                    allSignaturesValid &= compileAndKeep(sigId, expression, regExpTmpMap);
                 }
+            }
+
+            if (!allSignaturesValid || regExpTmpMap.isEmpty()) {
+                logError("Dictionary contains no complete, usable signature set");
+                return;
             }
 
             signaturesMap = Collections.unmodifiableMap(regExpTmpMap);
@@ -111,7 +117,7 @@ public class RunnableSigsLoader extends ARunnable {
     private static final Set<Character> SPECIAL_CHARS =
             Set.of('!', '@', '#', '$', '%', '^', '&', '*', '(', ')', '-', '+', '=', '{', '}', '[', ']', '|', '\\', ':', ';', '"', '\'', '<', '>', ',', '.', '?', '/');
 
-    private void compileAndKeep(String key, String regExpStr, Map<String, Pattern> map) {
+    private boolean compileAndKeep(String key, String regExpStr, Map<String, Pattern> map) {
         final String originalKeyName = key; // for logging aims
 
         if (key.endsWith("(regexp)")) {
@@ -138,8 +144,10 @@ public class RunnableSigsLoader extends ARunnable {
             // logInfo("Compiling key '{}' effective expressions = '{}'", originalKeyName, regExpStr);
             Pattern regExp = Pattern.compile(regExpStr, Pattern.CASE_INSENSITIVE + Pattern.DOTALL);
             map.put(key, regExp);
+            return true;
         } catch (PatternSyntaxException pse) {
             logError("Error while compiling signature with ID = '{}', reg-exp = '{}'", originalKeyName, regExpStr);
+            return false;
         }
     }
 

--- a/common/src/main/java/com/github/exadmin/cyberferret/logging/HandyLogging.java
+++ b/common/src/main/java/com/github/exadmin/cyberferret/logging/HandyLogging.java
@@ -5,13 +5,19 @@ import com.github.exadmin.cyberferret.utils.ConsoleUtils;
 public class HandyLogging {
     private final LoggerProxy loggerProxy = new LoggerProxy(getClass());
     protected boolean printToConsole = false;
+    private boolean silent = false;
 
 
     public void setPrintToConsole(boolean printToConsole) {
         this.printToConsole = printToConsole;
     }
 
+    public void setSilent(boolean silent) {
+        this.silent = silent;
+    }
+
     public void logError(String msg, Object... binds) {
+        if (silent) return;
         if (printToConsole) {
             ConsoleUtils.error(msg, binds);
         } else {
@@ -20,6 +26,7 @@ public class HandyLogging {
     }
 
     public void logWarn(String msg, Object... binds) {
+        if (silent) return;
         if (printToConsole) {
             ConsoleUtils.warn(msg, binds);
         } else {
@@ -28,6 +35,7 @@ public class HandyLogging {
     }
 
     public void logInfo(String msg, Object... binds) {
+        if (silent) return;
         if (printToConsole) {
             ConsoleUtils.info(msg, binds);
         } else {
@@ -36,6 +44,7 @@ public class HandyLogging {
     }
 
     public void logDebug(String msg, Object... binds) {
+        if (silent) return;
         if (printToConsole) {
             ConsoleUtils.debug(msg, binds);
         } else {
@@ -44,6 +53,7 @@ public class HandyLogging {
     }
 
     public void logTrace(String msg, Object... binds) {
+        if (silent) return;
         if (printToConsole) {
             ConsoleUtils.trace(msg, binds);
         } else {

--- a/common/src/test/java/com/github/exadmin/cyberferret/DictionarySessionTests.java
+++ b/common/src/test/java/com/github/exadmin/cyberferret/DictionarySessionTests.java
@@ -78,6 +78,23 @@ class DictionarySessionTests {
         assertEquals("Cannot parse the dictionary.", exception.getMessage());
     }
 
+    @Test
+    void prepare_rejectsIncompleteSignatureSets() throws Exception {
+        for (String dictionary : new String[]{
+                "VERSION=1.4\n",
+                "VERSION=1.4\nBROKEN(regexp)=[\n",
+                "VERSION=1.4\nSECRET=" + ENTRY + "\nBROKEN(regexp)=[\n"
+        }) {
+            writeEncryptedDictionary(dictionary);
+
+            DictionarySession.DictionaryException exception = assertThrows(
+                    DictionarySession.DictionaryException.class,
+                    () -> DictionarySession.prepare(tempDir, true, PASSWORD));
+
+            assertEquals("Cannot parse the dictionary.", exception.getMessage());
+        }
+    }
+
     private void writeEncryptedDictionary(String dictionary) throws Exception {
         Path encryptedPath = tempDir.resolve(AppConstants.DICTIONARY_FILE_PATH_ENCRYPTED);
         Files.writeString(encryptedPath, encrypt(dictionary, PASSWORD), StandardCharsets.UTF_8);

--- a/common/src/test/java/com/github/exadmin/cyberferret/DictionarySessionTests.java
+++ b/common/src/test/java/com/github/exadmin/cyberferret/DictionarySessionTests.java
@@ -1,0 +1,97 @@
+package com.github.exadmin.cyberferret;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import javax.crypto.Cipher;
+import javax.crypto.SecretKey;
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.PBEKeySpec;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.spec.KeySpec;
+import java.util.Base64;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class DictionarySessionTests {
+    private static final String PASSWORD = "test-password";
+    private static final String ENTRY = "SECRET_ENTRY_VALUE";
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void prepare_readsOfflineDictionaryAndVersion() throws Exception {
+        writeEncryptedDictionary("VERSION=1.4\nSECRET=" + ENTRY + "\n");
+
+        DictionarySession session = DictionarySession.prepare(tempDir, true, PASSWORD);
+
+        assertEquals("1.4", session.dictionaryVersion());
+        assertFalse(session.signaturesMap().isEmpty());
+    }
+
+    @Test
+    void prepare_returnsUnknownWhenVersionIsMissing() throws Exception {
+        writeEncryptedDictionary("SECRET=" + ENTRY + "\n");
+
+        DictionarySession session = DictionarySession.prepare(tempDir, true, PASSWORD);
+
+        assertEquals("unknown", session.dictionaryVersion());
+    }
+
+    @Test
+    void prepare_rejectsMissingOfflineDictionarySafely() {
+        DictionarySession.DictionaryException exception = assertThrows(
+                DictionarySession.DictionaryException.class,
+                () -> DictionarySession.prepare(tempDir, true, PASSWORD));
+
+        assertEquals("Cached dictionary is unavailable.", exception.getMessage());
+    }
+
+    @Test
+    void prepare_rejectsWrongPasswordWithoutSecretValues() throws Exception {
+        writeEncryptedDictionary("VERSION=1.4\nSECRET=" + ENTRY + "\n");
+
+        DictionarySession.DictionaryException exception = assertThrows(
+                DictionarySession.DictionaryException.class,
+                () -> DictionarySession.prepare(tempDir, true, "wrong-" + PASSWORD));
+
+        assertEquals("Cannot decrypt the dictionary.", exception.getMessage());
+        assertFalse(exception.toString().contains(PASSWORD));
+        assertFalse(exception.toString().contains(ENTRY));
+    }
+
+    @Test
+    void prepare_rejectsMalformedPropertiesSafely() throws Exception {
+        writeEncryptedDictionary("VERSION=1.4\nBROKEN=\\u12ZZ\n");
+
+        DictionarySession.DictionaryException exception = assertThrows(
+                DictionarySession.DictionaryException.class,
+                () -> DictionarySession.prepare(tempDir, true, PASSWORD));
+
+        assertEquals("Cannot parse the dictionary.", exception.getMessage());
+    }
+
+    private void writeEncryptedDictionary(String dictionary) throws Exception {
+        Path encryptedPath = tempDir.resolve(AppConstants.DICTIONARY_FILE_PATH_ENCRYPTED);
+        Files.writeString(encryptedPath, encrypt(dictionary, PASSWORD), StandardCharsets.UTF_8);
+    }
+
+    private static String encrypt(String value, String password) throws Exception {
+        byte[] salt = "bsd87918hediu".getBytes(StandardCharsets.UTF_8);
+        byte[] iv = {0, 2, 3, 4, 5, 4, 3, 2, 1, 0, 1, 2, 3, 4, 5, 0};
+        SecretKeyFactory factory = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA256");
+        KeySpec spec = new PBEKeySpec(password.toCharArray(), salt, 65536, 256);
+        SecretKey temporaryKey = factory.generateSecret(spec);
+        SecretKeySpec secretKey = new SecretKeySpec(temporaryKey.getEncoded(), "AES");
+        Cipher cipher = Cipher.getInstance("AES/CBC/PKCS5Padding");
+        cipher.init(Cipher.ENCRYPT_MODE, secretKey, new IvParameterSpec(iv));
+        return Base64.getEncoder().encodeToString(cipher.doFinal(value.getBytes(StandardCharsets.UTF_8)));
+    }
+}

--- a/common/src/test/java/com/github/exadmin/cyberferret/async/RunnableCheckOnlineDictionaryTests.java
+++ b/common/src/test/java/com/github/exadmin/cyberferret/async/RunnableCheckOnlineDictionaryTests.java
@@ -1,0 +1,60 @@
+package com.github.exadmin.cyberferret.async;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RunnableCheckOnlineDictionaryTests {
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void promoteDownloadedDictionary_keepsLastKnownGoodCacheWhenCandidateIsInvalid() throws Exception {
+        Path target = tempDir.resolve("dictionary.enc");
+        Path candidate = tempDir.resolve("candidate.tmp");
+        Files.writeString(target, "known-good", StandardCharsets.UTF_8);
+        Files.writeString(candidate, "invalid", StandardCharsets.UTF_8);
+        TestDownloader downloader = new TestDownloader();
+        downloader.setDownloadedDictionaryValidator(path -> false);
+
+        boolean promoted = downloader.promote(candidate, target);
+
+        assertFalse(promoted);
+        assertTrue(downloader.hasRejectedDownloadedDictionary());
+        assertEquals("known-good", Files.readString(target, StandardCharsets.UTF_8));
+    }
+
+    @Test
+    void promoteDownloadedDictionary_atomicallyReplacesCacheWhenCandidateIsValid() throws Exception {
+        Path target = tempDir.resolve("dictionary.enc");
+        Path candidate = tempDir.resolve("candidate.tmp");
+        Files.writeString(target, "known-good", StandardCharsets.UTF_8);
+        Files.writeString(candidate, "replacement", StandardCharsets.UTF_8);
+        TestDownloader downloader = new TestDownloader();
+        downloader.setDownloadedDictionaryValidator(path -> true);
+
+        boolean promoted = downloader.promote(candidate, target);
+
+        assertTrue(promoted);
+        assertFalse(downloader.hasRejectedDownloadedDictionary());
+        assertEquals("replacement", Files.readString(target, StandardCharsets.UTF_8));
+    }
+
+    private static final class TestDownloader extends RunnableCheckOnlineDictionary {
+        private TestDownloader() {
+            super(true);
+        }
+
+        private boolean promote(Path candidate, Path target) throws IOException {
+            return promoteDownloadedDictionary(candidate, target);
+        }
+    }
+}

--- a/common/src/test/java/com/github/exadmin/cyberferret/async/RunnableScannerGitFailureTests.java
+++ b/common/src/test/java/com/github/exadmin/cyberferret/async/RunnableScannerGitFailureTests.java
@@ -13,6 +13,7 @@ import java.util.Map;
 import java.util.regex.Pattern;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 public class RunnableScannerGitFailureTests {
     @TempDir
@@ -39,6 +40,8 @@ public class RunnableScannerGitFailureTests {
         assertTrue(messages.stream().anyMatch(message ->
                 message.type() == FxCallback.FxCallbackType.ERROR
                         && message.text().contains("Cannot list Git repository files")));
+        assertTrue(scanner.hasOperationalFailure());
+        assertFalse(scanner.isSuccessful());
     }
 
     private record CallbackMessage(FxCallback.FxCallbackType type, String text) {

--- a/common/src/test/java/com/github/exadmin/cyberferret/async/RunnableScannerTests.java
+++ b/common/src/test/java/com/github/exadmin/cyberferret/async/RunnableScannerTests.java
@@ -7,6 +7,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
@@ -124,6 +126,56 @@ public class RunnableScannerTests {
         List<FoundPathItem> foundItems = foundItemsContainer.getFoundItemsCopy();
         assertEquals(1, foundItems.size());
         assertEquals(stagedFile.toAbsolutePath().normalize(), foundItems.getFirst().getFilePath());
+    }
+
+    @Test
+    public void cliMode_hidesMatchedValueWhenFindingsAreNotRevealed() throws IOException {
+        Path repoRoot = tempDir.resolve("repo-safe-output");
+        Files.createDirectories(repoRoot.resolve(".git"));
+        Files.writeString(repoRoot.resolve(".git/config"), "[core]", StandardCharsets.UTF_8);
+        Path stagedFile = repoRoot.resolve("secret.txt");
+        String sentinel = "DO_NOT_PRINT_THIS_SECRET";
+        Files.writeString(stagedFile, sentinel, StandardCharsets.UTF_8);
+
+        RunnableScanner scanner = scannerFor(repoRoot, stagedFile, Pattern.compile(sentinel));
+        scanner.setRevealFindings(false);
+        scanner.setPrintToConsole(true);
+
+        PrintStream originalOut = System.out;
+        ByteArrayOutputStream captured = new ByteArrayOutputStream();
+        try {
+            System.setOut(new PrintStream(captured, true, StandardCharsets.UTF_8));
+            scanner.run();
+        } finally {
+            System.setOut(originalOut);
+        }
+
+        assertTrue(scanner.isAnySignatureFound());
+        assertFalse(captured.toString(StandardCharsets.UTF_8).contains(sentinel));
+    }
+
+    @Test
+    public void cliMode_marksMissingSelectedFileAsOperationalFailure() throws IOException {
+        Path repoRoot = tempDir.resolve("repo-missing-file");
+        Files.createDirectories(repoRoot.resolve(".git"));
+        Files.writeString(repoRoot.resolve(".git/config"), "[core]", StandardCharsets.UTF_8);
+        Path missingFile = repoRoot.resolve("missing.txt");
+
+        RunnableScanner scanner = scannerFor(repoRoot, missingFile, Pattern.compile("secret"));
+        scanner.run();
+
+        assertTrue(scanner.hasOperationalFailure());
+    }
+
+    private static RunnableScanner scannerFor(Path repoRoot, Path stagedFile, Pattern pattern) {
+        RunnableScanner scanner = new RunnableScanner(true);
+        scanner.setDirToScan(repoRoot.toString());
+        scanner.setFoundItemsContainer(new FoundItemsContainer());
+        scanner.setSignaturesMap(Map.of("test", pattern));
+        scanner.setAllowedSignaturesMap(Map.of());
+        scanner.setExcludeExtMap(Map.of());
+        scanner.setStagedFiles(List.of(stagedFile));
+        return scanner;
     }
 
     private static byte[] utf16LeWithBom(String value) {

--- a/common/src/test/java/com/github/exadmin/cyberferret/async/RunnableScannerTests.java
+++ b/common/src/test/java/com/github/exadmin/cyberferret/async/RunnableScannerTests.java
@@ -167,6 +167,22 @@ public class RunnableScannerTests {
         assertTrue(scanner.hasOperationalFailure());
     }
 
+    @Test
+    public void cliMode_marksEmptySignatureMapAsOperationalFailure() throws IOException {
+        Path repoRoot = tempDir.resolve("repo-empty-signatures");
+        Files.createDirectories(repoRoot.resolve(".git"));
+        Files.writeString(repoRoot.resolve(".git/config"), "[core]", StandardCharsets.UTF_8);
+
+        RunnableScanner scanner = new RunnableScanner(true);
+        scanner.setDirToScan(repoRoot.toString());
+        scanner.setFoundItemsContainer(new FoundItemsContainer());
+        scanner.setSignaturesMap(Map.of());
+        scanner.setStagedFiles(List.of());
+        scanner.run();
+
+        assertTrue(scanner.hasOperationalFailure());
+    }
+
     private static RunnableScanner scannerFor(Path repoRoot, Path stagedFile, Pattern pattern) {
         RunnableScanner scanner = new RunnableScanner(true);
         scanner.setDirToScan(repoRoot.toString());


### PR DESCRIPTION
## Context

This PR carries the automation interface for the quick CLI mode. It follows the upstream PR #13 work, which is now merged.

## Changes

- add `--mode=quick` with exit codes `0` for clean, `1` for findings, and `2` for incomplete or operational failure;
- keep detailed mode available for full finding output while suppressing matched values and file contents in quick mode;
- add optional `--cache-dir`, preserving the existing default cache resolution when omitted;
- add `--offline` so a caller can reuse one immutable dictionary snapshot;
- add `--dictionary-version` with exactly one validated, automation-safe output line;
- propagate scanner and Git-enumeration failures into the operational exit code.

## Verification

- `mvn -B clean package assembly:single`;
- real-JAR checks for clean, finding, and operational exit codes;
- parity coverage for Git ignore, allowed signatures, excluded extensions, and `grand-report.json` exclusions;
- secret-safe stdout/stderr checks and offline cache immutability check.