### PR TITLE
fix(hooks): support native CyberFerret CLI

### DIFF
--- a/.github/workflows/cfcli-release.yml
+++ b/.github/workflows/cfcli-release.yml
@@ -51,25 +51,27 @@ jobs:
       - name: Prepare release directory
         run: mkdir --parents dist
 
-      - name: Build Windows AMD64
+      - name: Build release binaries
         working-directory: cfcli
         env:
           CGO_ENABLED: "0"
-          GOARCH: amd64
-          GOOS: windows
-        run: >-
-          go build -trimpath -ldflags="-s -w -buildid="
-          -o ../dist/cfcli-windows-amd64.exe .
-
-      - name: Build Linux AMD64
-        working-directory: cfcli
-        env:
-          CGO_ENABLED: "0"
-          GOARCH: amd64
-          GOOS: linux
-        run: >-
-          go build -trimpath -ldflags="-s -w -buildid="
-          -o ../dist/cfcli-linux-amd64 .
+        shell: bash
+        run: |
+          set -euo pipefail
+          build() {
+            local goos="$1"
+            local goarch="$2"
+            local extension="$3"
+            GOOS="$goos" GOARCH="$goarch" go build \
+              -trimpath -ldflags="-s -w -buildid=" \
+              -o "../dist/cfcli-${goos}-${goarch}${extension}" .
+          }
+          build linux amd64 ""
+          build linux arm64 ""
+          build darwin amd64 ""
+          build darwin arm64 ""
+          build windows amd64 ".exe"
+          build windows arm64 ".exe"
 
       - name: Install UPX
         shell: bash
@@ -111,6 +113,10 @@ jobs:
             gh release create "$RELEASE_TAG" \
               dist/cfcli-windows-amd64.exe \
               dist/cfcli-linux-amd64 \
+              dist/cfcli-windows-arm64.exe \
+              dist/cfcli-linux-arm64 \
+              dist/cfcli-darwin-amd64 \
+              dist/cfcli-darwin-arm64 \
               --target "$RELEASE_TARGET" \
               --generate-notes \
               --title "$RELEASE_TAG"
@@ -118,6 +124,10 @@ jobs:
             gh release create "$RELEASE_TAG" \
               dist/cfcli-windows-amd64.exe \
               dist/cfcli-linux-amd64 \
+              dist/cfcli-windows-arm64.exe \
+              dist/cfcli-linux-arm64 \
+              dist/cfcli-darwin-amd64 \
+              dist/cfcli-darwin-arm64 \
               --verify-tag \
               --generate-notes \
               --title "$RELEASE_TAG"

--- a/.github/workflows/pre-commit-hook.yml
+++ b/.github/workflows/pre-commit-hook.yml
@@ -1,0 +1,30 @@
+name: Test pre-commit hook
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Test with pre-commit framework
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Install pre-commit
+        run: |
+          python3 -m venv "$RUNNER_TEMP/pre-commit-venv"
+          "$RUNNER_TEMP/pre-commit-venv/bin/pip" install pre-commit==4.6.0
+          echo "$RUNNER_TEMP/pre-commit-venv/bin" >> "$GITHUB_PATH"
+
+      - name: Test the CyberFerret hook
+        run: hooks/tests/cyberferret_hook_test.sh

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,8 +1,8 @@
 - id: cyberferret
   name: CyberFerret Sensitive Data Scanner
   description: >
-    Downloads the latest CyberFerret CLI jar from https://github.com/exadmin/CyberFerret
-    and scans staged files for sensitive data (passwords, tokens, keys, etc.).
+    Downloads the latest CyberFerret CLI from https://github.com/exadmin/CyberFerret
+    and scans staged files for sensitive data in quick mode.
     Requires CYBER_FERRET_PASSWORD environment variable to be set.
   language: script
   entry: hooks/cyberferret.sh

--- a/fx/src/test/java/com/github/exadmin/cyberferret/workflow/CfCliReleaseWorkflowTests.java
+++ b/fx/src/test/java/com/github/exadmin/cyberferret/workflow/CfCliReleaseWorkflowTests.java
@@ -35,7 +35,11 @@ class CfCliReleaseWorkflowTests {
         assertContains(workflow, "cancel-in-progress: false");
         assertContains(workflow, "timeout-minutes:");
         assertContains(workflow, "cfcli-windows-amd64.exe");
+        assertContains(workflow, "cfcli-windows-arm64.exe");
         assertContains(workflow, "cfcli-linux-amd64");
+        assertContains(workflow, "cfcli-linux-arm64");
+        assertContains(workflow, "cfcli-darwin-amd64");
+        assertContains(workflow, "cfcli-darwin-arm64");
         assertContains(workflow, "mkdir --parents dist");
         assertContains(workflow, "CGO_ENABLED: \"0\"");
         assertContains(workflow, "-trimpath");
@@ -67,7 +71,7 @@ class CfCliReleaseWorkflowTests {
 
     private static Path repositoryRoot() {
         Path candidate = Path.of(System.getProperty("user.dir")).toAbsolutePath();
-        while (candidate != null && !Files.isDirectory(candidate.resolve(".git"))) {
+        while (candidate != null && !Files.exists(candidate.resolve(".git"))) {
             candidate = candidate.getParent();
         }
         if (candidate == null) {

--- a/hooks/cyberferret.sh
+++ b/hooks/cyberferret.sh
@@ -2,23 +2,43 @@
 # CyberFerret pre-commit framework entry point.
 #
 # Required environment variable:
-#   CYBER_FERRET_PASSWORD  – decryption password for the signature dictionary
+#   CYBER_FERRET_PASSWORD - decryption password for the signature dictionary
 
 set -euo pipefail
 
-# ── OS-specific cache directory ────────────────────────────────────────────────
-case "$(uname -s 2>/dev/null || echo Unknown)" in
-    Linux*)        CF_CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/CyberFerret" ;;
-    Darwin*)       CF_CACHE_DIR="$HOME/Library/Caches/CyberFerret" ;;
-    CYGWIN*|MINGW*|MSYS*) CF_CACHE_DIR="${LOCALAPPDATA:-${APPDATA:-$HOME/AppData/Local}}/CyberFerret" ;;
-    *)             CF_CACHE_DIR="$HOME/.cache/CyberFerret" ;;
+# Select the release asset for the host platform.
+case "$(uname -s 2>/dev/null || printf 'Unknown\n')" in
+    Linux*) CF_OS="linux"; CF_EXTENSION="" ;;
+    Darwin*) CF_OS="darwin"; CF_EXTENSION="" ;;
+    CYGWIN*|MINGW*|MSYS*) CF_OS="windows"; CF_EXTENSION=".exe" ;;
+    *)
+        echo "[CyberFerret] ERROR: unsupported operating system" >&2
+        exit 1
+        ;;
+esac
+
+case "$(uname -m 2>/dev/null || printf 'Unknown\n')" in
+    x86_64|amd64) CF_ARCH="amd64" ;;
+    arm64|aarch64) CF_ARCH="arm64" ;;
+    *)
+        echo "[CyberFerret] ERROR: unsupported architecture" >&2
+        exit 1
+        ;;
+esac
+
+# Use the platform cache directory.
+case "$CF_OS" in
+    linux) CF_CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/CyberFerret" ;;
+    darwin) CF_CACHE_DIR="$HOME/Library/Caches/CyberFerret" ;;
+    windows) CF_CACHE_DIR="${LOCALAPPDATA:-${APPDATA:-$HOME/AppData/Local}}/CyberFerret" ;;
 esac
 
 mkdir -p "$CF_CACHE_DIR"
 
-# ── Download latest jar if a newer release is available ───────────────────────
-JAR_PATH="$CF_CACHE_DIR/cyberferret-cli.jar"
-VERSION_FILE="$CF_CACHE_DIR/.cyberferret-version"
+# Download the latest native CLI when the cached release is outdated.
+BINARY_NAME="cfcli-${CF_OS}-${CF_ARCH}${CF_EXTENSION}"
+CLI_PATH="$CF_CACHE_DIR/$BINARY_NAME"
+VERSION_FILE="$CF_CACHE_DIR/.cfcli-${CF_OS}-${CF_ARCH}-version"
 GITHUB_API_URL="https://api.github.com/repos/exadmin/CyberFerret/releases/latest"
 
 RELEASE_JSON="$(curl -sf --connect-timeout 10 "$GITHUB_API_URL")" \
@@ -28,41 +48,45 @@ RELEASE_JSON="$(curl -sf --connect-timeout 10 "$GITHUB_API_URL")" \
 if command -v python3 >/dev/null 2>&1; then
     LATEST_TAG="$(printf '%s' "$RELEASE_JSON" \
         | python3 -c 'import json,sys; print(json.load(sys.stdin)["tag_name"])')"
-    JAR_URL="$(printf '%s' "$RELEASE_JSON" \
-        | python3 -c 'import json,sys; d=json.load(sys.stdin); print(next(a["browser_download_url"] for a in d["assets"] if a["name"]=="cyberferret-cli.jar"))')"
+    ASSET_URL="$(printf '%s' "$RELEASE_JSON" \
+        | python3 -c 'import json,sys; d=json.load(sys.stdin); name=sys.argv[1]; print(next((a["browser_download_url"] for a in d["assets"] if a["name"]==name), ""))' "$BINARY_NAME")"
 else
     LATEST_TAG="$(printf '%s' "$RELEASE_JSON" \
         | grep '"tag_name"' | head -1 \
         | sed 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/')"
-    JAR_URL="$(printf '%s' "$RELEASE_JSON" \
-        | grep '"browser_download_url"' | grep 'cyberferret-cli\.jar' | head -1 \
+    ASSET_URL="$(printf '%s' "$RELEASE_JSON" \
+        | grep '"browser_download_url"' | grep -F "/$BINARY_NAME\"" | head -1 \
         | sed 's/.*"browser_download_url"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/')"
 fi
 
 [ -n "$LATEST_TAG" ] || { echo "[CyberFerret] ERROR: failed to parse release tag" >&2; exit 1; }
-[ -n "$JAR_URL" ]    || { echo "[CyberFerret] ERROR: cyberferret-cli.jar asset not found in release $LATEST_TAG" >&2; exit 1; }
+[ -n "$ASSET_URL" ] || {
+    echo "[CyberFerret] ERROR: $BINARY_NAME asset not found in release $LATEST_TAG" >&2
+    exit 1
+}
 
 CACHED_TAG="$(cat "$VERSION_FILE" 2>/dev/null || true)"
-if [ ! -f "$JAR_PATH" ] || [ "$CACHED_TAG" != "$LATEST_TAG" ]; then
+if [ ! -x "$CLI_PATH" ] || [ "$CACHED_TAG" != "$LATEST_TAG" ]; then
     echo "[CyberFerret] Downloading $LATEST_TAG ..." >&2
-    _tmp="${JAR_PATH}.tmp.$$"
-    if curl -fL --connect-timeout 60 -o "$_tmp" "$JAR_URL"; then
-        mv "$_tmp" "$JAR_PATH"
+    _tmp="${CLI_PATH}.tmp.$$"
+    if curl -fL --connect-timeout 60 -o "$_tmp" "$ASSET_URL"; then
+        chmod 0755 "$_tmp"
+        mv "$_tmp" "$CLI_PATH"
         printf '%s' "$LATEST_TAG" > "$VERSION_FILE"
         echo "[CyberFerret] Download complete." >&2
     else
         rm -f "$_tmp"
-        echo "[CyberFerret] ERROR: jar download failed" >&2
+        echo "[CyberFerret] ERROR: CLI download failed" >&2
         exit 1
     fi
 fi
 
-# ── Build staged-file list ─────────────────────────────────────────────────────
+# Build the staged-file list.
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 FILES_LIST="$(mktemp)"
 trap 'rm -f "$FILES_LIST"' EXIT
 
-# Pass relative paths – CyberFerretCLI resolves them against REPO_ROOT.
+# Pass relative paths. CyberFerret resolves them against REPO_ROOT.
 git diff --cached --name-only > "$FILES_LIST"
 
 if [ ! -s "$FILES_LIST" ]; then
@@ -70,8 +94,8 @@ if [ ! -s "$FILES_LIST" ]; then
     exit 0
 fi
 
-# ── Run CyberFerret (PWD = cache dir so all temp/cache files land there) ──────
+# Run CyberFerret in quick mode and preserve its exit code.
 cd "$CF_CACHE_DIR"
-exec java -cp "$JAR_PATH" \
-    com.github.exadmin.cyberferret.CyberFerretCLI \
-    "$REPO_ROOT" "$FILES_LIST"
+SCAN_STATUS=0
+"$CLI_PATH" --mode=quick "$REPO_ROOT" "$FILES_LIST" || SCAN_STATUS=$?
+exit "$SCAN_STATUS"

--- a/hooks/tests/cyberferret_hook_test.sh
+++ b/hooks/tests/cyberferret_hook_test.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+REPOSITORY_ROOT="$(git rev-parse --show-toplevel)"
+TEST_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+HOOK_REPOSITORY="$TEST_ROOT/hook-repository"
+CONSUMER_REPOSITORY="$TEST_ROOT/consumer-repository"
+FAKE_BIN_DIR="$TEST_ROOT/bin"
+MARKER_FILE="$TEST_ROOT/cfcli-invoked"
+
+mkdir -p "$HOOK_REPOSITORY/hooks" "$CONSUMER_REPOSITORY" "$FAKE_BIN_DIR"
+cp "$REPOSITORY_ROOT/.pre-commit-hooks.yaml" "$HOOK_REPOSITORY/.pre-commit-hooks.yaml"
+cp "$REPOSITORY_ROOT/hooks/cyberferret.sh" "$HOOK_REPOSITORY/hooks/cyberferret.sh"
+
+git -C "$HOOK_REPOSITORY" init --quiet
+git -C "$HOOK_REPOSITORY" config user.email "cyberferret-hook-test@example.invalid"
+git -C "$HOOK_REPOSITORY" config user.name "CyberFerret hook test"
+git -C "$HOOK_REPOSITORY" add .pre-commit-hooks.yaml hooks/cyberferret.sh
+git -C "$HOOK_REPOSITORY" commit --quiet -m "test: prepare hook repository"
+HOOK_REVISION="$(git -C "$HOOK_REPOSITORY" rev-parse HEAD)"
+
+cat > "$FAKE_BIN_DIR/uname" <<'EOF'
+#!/usr/bin/env bash
+case "${1:-}" in
+    -s) printf 'Linux\n' ;;
+    -m) printf 'x86_64\n' ;;
+    *) printf 'Linux\n' ;;
+esac
+EOF
+
+cat > "$FAKE_BIN_DIR/curl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+output_file=""
+url=""
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        -o|--output)
+            output_file="$2"
+            shift 2
+            ;;
+        -*)
+            shift
+            ;;
+        *)
+            url="$1"
+            shift
+            ;;
+    esac
+done
+
+if [ -z "$output_file" ]; then
+    printf '%s\n' "$CF_TEST_RELEASE_JSON"
+    exit 0
+fi
+
+if [ "$url" != "https://downloads.example/cfcli-linux-amd64" ]; then
+    printf 'Unexpected asset URL: %s\n' "$url" >&2
+    exit 1
+fi
+cp "$CF_TEST_CLI" "$output_file"
+EOF
+
+cat > "$TEST_ROOT/cfcli-linux-amd64" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+[ "$#" -eq 3 ]
+[ "$1" = "--mode=quick" ]
+[ -d "$2" ]
+[ -f "$3" ]
+grep --fixed-strings --line-regexp "staged.txt" "$3" >/dev/null
+printf 'invoked\n' > "$CF_TEST_MARKER"
+EOF
+chmod +x "$FAKE_BIN_DIR/uname" "$FAKE_BIN_DIR/curl" "$TEST_ROOT/cfcli-linux-amd64"
+
+git -C "$CONSUMER_REPOSITORY" init --quiet
+git -C "$CONSUMER_REPOSITORY" config user.email "cyberferret-consumer-test@example.invalid"
+git -C "$CONSUMER_REPOSITORY" config user.name "CyberFerret consumer test"
+printf 'safe content\n' > "$CONSUMER_REPOSITORY/staged.txt"
+git -C "$CONSUMER_REPOSITORY" add staged.txt
+
+cat > "$CONSUMER_REPOSITORY/.pre-commit-config.yaml" <<EOF
+repos:
+  - repo: file://$HOOK_REPOSITORY
+    rev: $HOOK_REVISION
+    hooks:
+      - id: cyberferret
+EOF
+
+(
+    cd "$CONSUMER_REPOSITORY"
+    CF_TEST_RELEASE_JSON='{"tag_name":"cfcli-v2.0.4","assets":[{"name":"cfcli-linux-amd64","browser_download_url":"https://downloads.example/cfcli-linux-amd64"}]}' \
+    CF_TEST_CLI="$TEST_ROOT/cfcli-linux-amd64" \
+    CF_TEST_MARKER="$MARKER_FILE" \
+    PRE_COMMIT_HOME="$TEST_ROOT/pre-commit-cache" \
+    XDG_CACHE_HOME="$TEST_ROOT/cache" \
+    PATH="$FAKE_BIN_DIR:$PATH" \
+        pre-commit run cyberferret --config .pre-commit-config.yaml --verbose
+)
+
+test -f "$MARKER_FILE"


### PR DESCRIPTION
## Summary

- Replace the Java JAR bootstrap with platform-specific CyberFerret CLI release downloads and run staged files in quick mode.
- Publish Linux, Windows, and macOS binaries for amd64 and arm64 from the CF CLI release workflow.
- Add a CI integration test that installs pre-commit, loads the repository hook, and verifies native asset selection, staged-file forwarding, and CLI arguments.

## Testing

- mvn test
- go test -count=1 ./...
- go vet ./...
- Cross-compiled all six release targets with CGO disabled
- bash hooks/tests/cyberferret_hook_test.sh
- shellcheck hooks/cyberferret.sh hooks/tests/cyberferret_hook_test.sh
- actionlint .github/workflows/cfcli-release.yml .github/workflows/pre-commit-hook.yml